### PR TITLE
re-set java ctx on resume

### DIFF
--- a/cmd/core/mobile/env.go
+++ b/cmd/core/mobile/env.go
@@ -452,6 +452,9 @@ func ArchNDK() string {
 				arch = "x86_64"
 				break
 			}
+			if runtime.GOOS == "android" { // termux
+				return "linux-aarch64"
+			}
 			fallthrough
 		default:
 			panic("unsupported GOARCH: " + runtime.GOARCH)

--- a/cmd/core/mobile/env.go
+++ b/cmd/core/mobile/env.go
@@ -452,9 +452,6 @@ func ArchNDK() string {
 				arch = "x86_64"
 				break
 			}
-			if runtime.GOOS == "android" { // termux
-				return "linux-aarch64"
-			}
 			fallthrough
 		default:
 			panic("unsupported GOARCH: " + runtime.GOARCH)

--- a/system/driver/android/android.c
+++ b/system/driver/android/android.c
@@ -77,6 +77,16 @@ jint JNI_OnLoad(JavaVM *vm, void *reserved)
 
 static int main_running = 0;
 
+// ensure we refresh context on resume in case something has changed...
+void onResume(ANativeActivity *activity) {
+	JNIEnv* env = activity->env;
+	setCurrentContext(activity->vm, (*env)->NewGlobalRef(env, activity->clazz));
+}
+
+void onStart(ANativeActivity *activity) {}
+void onPause(ANativeActivity *activity) {}
+void onStop(ANativeActivity *activity) {}
+
 // Entry point from our subclassed NativeActivity.
 //
 // By here, the Go runtime has been initialized (as we are running in

--- a/system/driver/android/android.go
+++ b/system/driver/android/android.go
@@ -106,25 +106,9 @@ func callMain(mainPC uintptr) {
 	go callfn.CallFn(mainPC)
 }
 
-//export onStart
-func onStart(activity *C.ANativeActivity) {
-}
-
-//export onResume
-func onResume(activity *C.ANativeActivity) {
-}
-
 //export onSaveInstanceState
 func onSaveInstanceState(activity *C.ANativeActivity, outSize *C.size_t) unsafe.Pointer {
 	return nil
-}
-
-//export onPause
-func onPause(activity *C.ANativeActivity) {
-}
-
-//export onStop
-func onStop(activity *C.ANativeActivity) {
 }
 
 //export onCreate


### PR DESCRIPTION
it is "only" sugest to fix same problem as fyne ............., on resume java context do not work ..., also I dare unused function move to C code to avoid GO runtime, of course you can reject for example some clever  way, but this was my idea to fix ..., you can free change it ...