### PR TITLE
add lf at end of bytes -- turns out it is a standard..

### DIFF
--- a/texteditor/editor_test.go
+++ b/texteditor/editor_test.go
@@ -85,7 +85,7 @@ func TestEditorChange(t *testing.T) {
 		mods.SetFlag(true, key.Control)
 		ed.HandleEvent(events.NewKey(events.KeyChord, 0, key.CodeReturnEnter, mods))
 		assert.Equal(t, 1, n)
-		assert.Equal(t, "Go\n", text)
+		assert.Equal(t, "Go\n\n", text)
 	})
 }
 
@@ -101,12 +101,12 @@ func TestEditorInput(t *testing.T) {
 	b.AssertRender(t, "input", func() {
 		ed.HandleEvent(events.NewKey(events.KeyChord, 'G', 0, 0))
 		assert.Equal(t, 1, n)
-		assert.Equal(t, "G", text)
+		assert.Equal(t, "G\n", text)
 		ed.HandleEvent(events.NewKey(events.KeyChord, 'o', 0, 0))
 		assert.Equal(t, 2, n)
-		assert.Equal(t, "Go", text)
+		assert.Equal(t, "Go\n", text)
 		ed.HandleEvent(events.NewKey(events.KeyChord, 0, key.CodeReturnEnter, 0))
 		assert.Equal(t, 3, n)
-		assert.Equal(t, "Go\n", text)
+		assert.Equal(t, "Go\n\n", text)
 	})
 }

--- a/texteditor/text/lines.go
+++ b/texteditor/text/lines.go
@@ -137,6 +137,7 @@ func (ls *Lines) SetTextLines(lns [][]byte) {
 }
 
 // Bytes returns the current text lines as a slice of bytes,
+// with an additional line feed at the end, per POSIX standards.
 func (ls *Lines) Bytes() []byte {
 	ls.Lock()
 	defer ls.Unlock()
@@ -642,15 +643,10 @@ func (ls *Lines) initFromLineBytes() {
 }
 
 // bytes returns the current text lines as a slice of bytes.
+// with an additional line feed at the end, per POSIX standards.
 func (ls *Lines) bytes() []byte {
 	txt := bytes.Join(ls.lineBytes, []byte("\n"))
-	return txt
-}
-
-// bytesLF returns the current text lines as a slice of bytes,
-// with an additional line feed at the end, needed for passing code to markup.
-func (ls *Lines) bytesLF() []byte {
-	txt := ls.bytes()
+	// https://stackoverflow.com/questions/729692/why-should-text-files-end-with-a-newline
 	txt = append(txt, []byte("\n")...)
 	return txt
 }
@@ -1269,7 +1265,7 @@ func (ls *Lines) initialMarkup() {
 	}
 	if ls.Highlighter.UsingParse() {
 		fs := ls.ParseState.Done() // initialize
-		fs.Src.SetBytes(ls.bytesLF())
+		fs.Src.SetBytes(ls.bytes())
 	}
 	mxhi := min(100, ls.numLines())
 	txt := bytes.Join(ls.lineBytes[:mxhi], []byte("\n"))
@@ -1357,7 +1353,7 @@ func (ls *Lines) adjustedTagsLine(tags lexer.Line, ln int) lexer.Line {
 // Does not start or end with lock, but acquires at end to apply.
 func (ls *Lines) asyncMarkup() {
 	ls.Lock()
-	txt := ls.bytesLF()
+	txt := ls.bytes()
 	ls.markupEdits = nil // only accumulate after this point; very rare
 	ls.Unlock()
 


### PR DESCRIPTION
https://stackoverflow.com/questions/729692/why-should-text-files-end-with-a-newline