### PR TITLE
use Restyle instead of Update in scroll position -- fixes excessive layout with texteditors

### DIFF
--- a/core/scroll.go
+++ b/core/scroll.go
@@ -169,7 +169,7 @@ func (fr *Frame) positionScroll(d math32.Dims) {
 	sb.SetValue(sb.Value) // keep in range
 	fr.This.(Layouter).SetScrollParams(d, sb)
 
-	sb.Update() // applies style
+	sb.Restyle() // applies style
 	sb.SizeUp()
 	sb.Geom.Size.Alloc = fr.Geom.Size.Actual
 	sb.SizeDown(0)


### PR DESCRIPTION
for #1056 -- tested on android device native and it seemed smoother, though still not great.

@kkoreilly can you test on various web platforms?  it is too slow here at the hospital.

