### PR TITLE
Make slide scrolling smoother by adding a continued scrolling velocity

### DIFF
--- a/core/frame.go
+++ b/core/frame.go
@@ -152,7 +152,8 @@ func (fr *Frame) Init() {
 		fr.scrollDelta(events.NewScroll(e.WindowPos(), del, e.Modifiers()))
 	})
 	fr.On(events.SlideStop, func(e events.Event) {
-		fmt.Println(e.StartDelta(), e.SinceStart())
+		vel := math32.Vector2FromPoint(e.StartDelta()).DivScalar(float32(e.SinceStart().Milliseconds()))
+		fmt.Println(vel)
 	})
 }
 

--- a/core/frame.go
+++ b/core/frame.go
@@ -162,7 +162,9 @@ func (fr *Frame) Init() {
 			i := 0
 			tick := time.NewTicker(time.Second / 60)
 			for range tick.C {
+				fr.AsyncLock()
 				fr.scrollDelta(events.NewScroll(e.WindowPos(), vel, e.Modifiers()))
+				fr.AsyncUnlock()
 				vel.SetMulScalar(0.9)
 				i++
 				if i > 60 {

--- a/core/frame.go
+++ b/core/frame.go
@@ -153,6 +153,11 @@ func (fr *Frame) Init() {
 	})
 	fr.On(events.SlideStop, func(e events.Event) {
 		vel := math32.Vector2FromPoint(e.StartDelta()).DivScalar(float32(e.SinceStart().Milliseconds()))
+		hasX := math32.Abs(vel.X) > 0.8
+		hasY := math32.Abs(vel.Y) > 0.8
+		if !hasX && !hasY {
+			return
+		}
 		fmt.Println(vel)
 	})
 }

--- a/core/frame.go
+++ b/core/frame.go
@@ -154,7 +154,7 @@ func (fr *Frame) Init() {
 		// If we have enough velocity, we continue scrolling over the
 		// next second in a goroutine while slowly decelerating for a
 		// smoother experience.
-		vel := math32.Vector2FromPoint(e.StartDelta()).DivScalar(float32(e.SinceStart().Milliseconds())).Negate()
+		vel := math32.Vector2FromPoint(e.StartDelta()).DivScalar(1.5 * float32(e.SinceStart().Milliseconds())).Negate()
 		if math32.Abs(vel.X) < 1 && math32.Abs(vel.Y) < 1 {
 			return
 		}
@@ -165,9 +165,9 @@ func (fr *Frame) Init() {
 				fr.AsyncLock()
 				fr.scrollDelta(events.NewScroll(e.WindowPos(), vel, e.Modifiers()))
 				fr.AsyncUnlock()
-				vel.SetMulScalar(0.9)
+				vel.SetMulScalar(0.95)
 				i++
-				if i > 60 {
+				if i > 120 {
 					tick.Stop()
 					break
 				}

--- a/core/frame.go
+++ b/core/frame.go
@@ -5,6 +5,7 @@
 package core
 
 import (
+	"fmt"
 	"log/slog"
 	"time"
 	"unicode"
@@ -144,11 +145,14 @@ func (fr *Frame) Init() {
 	fr.On(events.Scroll, func(e events.Event) {
 		fr.scrollDelta(e)
 	})
-	// we treat slide events on layouts as scroll events
-	// we must reverse the delta for "natural" scrolling behavior
+	// We treat slide events on frames as scroll events.
 	fr.On(events.SlideMove, func(e events.Event) {
+		// We must negate the delta for "natural" scrolling behavior.
 		del := math32.Vector2FromPoint(e.PrevDelta()).MulScalar(-0.034)
 		fr.scrollDelta(events.NewScroll(e.WindowPos(), del, e.Modifiers()))
+	})
+	fr.On(events.SlideStop, func(e events.Event) {
+		fmt.Println(e.StartDelta(), e.SinceStart())
 	})
 }
 

--- a/core/frame.go
+++ b/core/frame.go
@@ -151,14 +151,13 @@ func (fr *Frame) Init() {
 		fr.scrollDelta(events.NewScroll(e.WindowPos(), del, e.Modifiers()))
 	})
 	fr.On(events.SlideStop, func(e events.Event) {
+		// If we have enough velocity, we continue scrolling over the
+		// next second in a goroutine while slowly decelerating for a
+		// smoother experience.
 		vel := math32.Vector2FromPoint(e.StartDelta()).DivScalar(float32(e.SinceStart().Milliseconds())).Negate()
-		hasX := math32.Abs(vel.X) > 1
-		hasY := math32.Abs(vel.Y) > 1
-		if !hasX && !hasY {
+		if math32.Abs(vel.X) < 1 && math32.Abs(vel.Y) < 1 {
 			return
 		}
-		// If we have enough velocity, we continue scrolling over the
-		// next second in a goroutine while slowly decelerating.
 		go func() {
 			i := 0
 			tick := time.NewTicker(time.Second / 60)

--- a/events/source.go
+++ b/events/source.go
@@ -94,6 +94,12 @@ func (es *Source) KeyChord(rn rune, code key.Codes, mods key.Modifiers) {
 // MouseButton creates and sends a mouse button event with given values
 func (es *Source) MouseButton(typ Types, but Buttons, where image.Point, mods key.Modifiers) {
 	ev := NewMouse(typ, but, where, mods)
+	if es.Last.MouseButtonType == MouseDown {
+		ev.StTime = es.Last.MouseDownTime
+		ev.PrvTime = es.Last.MouseMoveTime
+		ev.Start = es.Last.MouseDownPos
+		ev.Prev = es.Last.MousePos
+	}
 	es.Last.Mods = mods
 	es.Last.MouseButtonType = typ
 	es.Last.MouseButton = but

--- a/events/source.go
+++ b/events/source.go
@@ -94,7 +94,7 @@ func (es *Source) KeyChord(rn rune, code key.Codes, mods key.Modifiers) {
 // MouseButton creates and sends a mouse button event with given values
 func (es *Source) MouseButton(typ Types, but Buttons, where image.Point, mods key.Modifiers) {
 	ev := NewMouse(typ, but, where, mods)
-	if typ == MouseUp && es.Last.MouseButtonType == MouseDown {
+	if typ != MouseDown && es.Last.MouseButtonType == MouseDown {
 		ev.StTime = es.Last.MouseDownTime
 		ev.PrvTime = es.Last.MouseMoveTime
 		ev.Start = es.Last.MouseDownPos

--- a/events/source.go
+++ b/events/source.go
@@ -94,7 +94,7 @@ func (es *Source) KeyChord(rn rune, code key.Codes, mods key.Modifiers) {
 // MouseButton creates and sends a mouse button event with given values
 func (es *Source) MouseButton(typ Types, but Buttons, where image.Point, mods key.Modifiers) {
 	ev := NewMouse(typ, but, where, mods)
-	if es.Last.MouseButtonType == MouseDown {
+	if typ == MouseUp && es.Last.MouseButtonType == MouseDown {
 		ev.StTime = es.Last.MouseDownTime
 		ev.PrvTime = es.Last.MouseMoveTime
 		ev.Start = es.Last.MouseDownPos


### PR DESCRIPTION
If we have enough velocity, we continue scrolling over the next second in a goroutine while slowly decelerating for a smoother experience.

Fixes #1058