### PR TITLE
make default screen name main for AppSingle so that + on screen settings does not immediately screw things up

### DIFF
--- a/system/driver/base/app_single.go
+++ b/system/driver/base/app_single.go
@@ -62,7 +62,7 @@ type AppSingler interface {
 // NewAppSingle makes a new [AppSingle].
 func NewAppSingle[D system.Drawer, W system.Window]() AppSingle[D, W] {
 	return AppSingle[D, W]{
-		Scrn: &system.Screen{},
+		Scrn: &system.Screen{Name: "main"},
 	}
 }
 


### PR DESCRIPTION
This makes #1083 much less potent of an issue.