### PR TITLE
Improve handling of read only duration input and chooser

### DIFF
--- a/core/chooser.go
+++ b/core/chooser.go
@@ -173,24 +173,28 @@ func (ch *Chooser) Init() {
 	ch.SetIcon(icons.None).SetIndicator(icons.KeyboardArrowDown)
 	ch.CurrentIndex = -1
 	ch.Styler(func(s *styles.Style) {
-		s.SetAbilities(true, abilities.Activatable, abilities.Hoverable, abilities.LongHoverable)
-		if !ch.Editable {
-			s.SetAbilities(true, abilities.Focusable)
+		if !s.IsReadOnly() {
+			s.SetAbilities(true, abilities.Activatable, abilities.Hoverable, abilities.LongHoverable)
+			if !ch.Editable {
+				s.SetAbilities(true, abilities.Focusable)
+			}
 		}
-		s.Cursor = cursors.Pointer
 		s.Text.Align = styles.Center
 		s.Border.Radius = styles.BorderRadiusSmall
 		s.Padding.Set(units.Dp(8), units.Dp(16))
 		s.CenterAll()
-		switch ch.Type {
-		case ChooserFilled:
-			s.Background = colors.Scheme.Secondary.Container
-			s.Color = colors.Scheme.Secondary.OnContainer
-		case ChooserOutlined:
-			if !s.Is(states.Focused) {
-				s.Border.Style.Set(styles.BorderSolid)
-				s.Border.Width.Set(units.Dp(1))
-				s.Border.Color.Set(colors.Scheme.OnSurfaceVariant)
+		if !s.IsReadOnly() {
+			s.Cursor = cursors.Pointer
+			switch ch.Type {
+			case ChooserFilled:
+				s.Background = colors.Scheme.Secondary.Container
+				s.Color = colors.Scheme.Secondary.OnContainer
+			case ChooserOutlined:
+				if !s.Is(states.Focused) {
+					s.Border.Style.Set(styles.BorderSolid)
+					s.Border.Width.Set(units.Dp(1))
+					s.Border.Color.Set(colors.Scheme.OnSurfaceVariant)
+				}
 			}
 		}
 		// textfield handles everything
@@ -206,6 +210,9 @@ func (ch *Chooser) Init() {
 	})
 
 	ch.OnClick(func(e events.Event) {
+		if ch.IsReadOnly() {
+			return
+		}
 		if ch.openMenu(e) {
 			e.SetHandled()
 		}
@@ -369,7 +376,7 @@ func (ch *Chooser) Init() {
 			ch.Indicator = icons.KeyboardArrowRight
 		}
 		// editable handles through TextField
-		if !ch.Editable {
+		if !ch.Editable && !ch.IsReadOnly() {
 			tree.AddAt(p, "indicator", func(w *Icon) {
 				w.Styler(func(s *styles.Style) {
 					s.Justify.Self = styles.End

--- a/core/flags.go
+++ b/core/flags.go
@@ -55,11 +55,9 @@ func (wb *WidgetBase) IsDisabled() bool {
 	return wb.StateIs(states.Disabled)
 }
 
-// IsReadOnly returns whether this node is flagged as [ReadOnly] or [Disabled].
-// If so, behave appropriately. Styling is based on each state separately,
-// but behaviors are often the same for both of these states.
+// IsReadOnly returns whether this widget is flagged as either [states.ReadOnly] or [states.Disabled].
 func (wb *WidgetBase) IsReadOnly() bool {
-	return wb.StateIs(states.ReadOnly) || wb.StateIs(states.Disabled)
+	return wb.Styles.IsReadOnly()
 }
 
 // SetReadOnly sets the [states.ReadOnly] flag to the given value.

--- a/core/timepicker.go
+++ b/core/timepicker.go
@@ -432,6 +432,7 @@ func (di *DurationInput) Init() {
 				di.setAutoUnit()
 			}
 			w.SetValue(float32(di.Duration) / float32(durationUnitsMap[di.Unit]))
+			w.SetReadOnly(di.IsReadOnly())
 		})
 		w.OnChange(func(e events.Event) {
 			di.Duration = time.Duration(w.Value * float32(durationUnitsMap[di.Unit]))
@@ -448,6 +449,9 @@ func (di *DurationInput) Init() {
 
 		w.SetItems(units...)
 		w.SetTooltip("The unit of time")
+		w.Updater(func() {
+			w.SetReadOnly(di.IsReadOnly())
+		})
 		w.OnChange(func(e events.Event) {
 			di.Update()
 		})

--- a/core/timepicker_test.go
+++ b/core/timepicker_test.go
@@ -28,3 +28,15 @@ func TestTimeInputTime(t *testing.T) {
 	NewTimeInput(b).SetTime(testTime).SetDisplayDate(false)
 	b.AssertRender(t, "time-input/time")
 }
+
+func TestDurationInput(t *testing.T) {
+	b := NewBody()
+	NewDurationInput(b).SetDuration(2 * time.Minute)
+	b.AssertRender(t, "duration-input/basic")
+}
+
+func TestDurationInputReadOnly(t *testing.T) {
+	b := NewBody()
+	NewDurationInput(b).SetDuration(2 * time.Minute).SetReadOnly(true)
+	b.AssertRender(t, "duration-input/read-only")
+}

--- a/styles/style.go
+++ b/styles/style.go
@@ -332,7 +332,7 @@ func (s *Style) AbilityIs(able abilities.Abilities) bool {
 	return s.Abilities.HasFlag(able)
 }
 
-// SetState sets the given [states.State] flags to the given value
+// SetState sets the given [states.States] flags to the given value
 func (s *Style) SetState(on bool, state ...states.States) *Style {
 	bfs := make([]enums.BitFlag, len(state))
 	for i, st := range state {
@@ -346,6 +346,11 @@ func (s *Style) SetState(on bool, state ...states.States) *Style {
 func (s *Style) SetEnabled(on bool) *Style {
 	s.State.SetFlag(!on, states.Disabled)
 	return s
+}
+
+// IsReadOnly returns whether this style object is flagged as either [states.ReadOnly] or [states.Disabled].
+func (s *Style) IsReadOnly() bool {
+	return s.Is(states.ReadOnly) || s.Is(states.Disabled)
 }
 
 // SetAbilities sets the given [states.State] flags to the given value


### PR DESCRIPTION
Fixes #1141. More progress for #677.

Some issues remain for read only duration input styling, but those can be handled as part of #1142. One question is whether we want to make `ReadOnly` automatically inherited, which would make things like this easier. There is also an outstanding issue regarding events being captured by read only multi-child widgets in tables, which we can fix as part of #677.