### PR TITLE
improve handling of index description in pages pre render data

### DIFF
--- a/cmd/core/web/build.go
+++ b/cmd/core/web/build.go
@@ -112,6 +112,7 @@ func makeFiles(c *config.Config) error {
 		}
 	}
 	preRenderHTMLIndex := preRenderHTML
+	preRenderDescriptionIndex := ""
 	pagesPreRenderData := &ppath.PreRenderData{}
 	if strings.HasPrefix(preRenderHTML, "{") {
 		err := jsonx.Read(pagesPreRenderData, strings.NewReader(preRenderHTML))
@@ -119,11 +120,14 @@ func makeFiles(c *config.Config) error {
 			return err
 		}
 		preRenderHTMLIndex = pagesPreRenderData.HTML[""]
+		if c.About == "" {
+			preRenderDescriptionIndex = pagesPreRenderData.Description[""]
+		}
 		if c.Pages == "" {
 			c.Pages = "content"
 		}
 	}
-	iht, err := makeIndexHTML(c, "", "", "", preRenderHTMLIndex)
+	iht, err := makeIndexHTML(c, "", "", preRenderDescriptionIndex, preRenderHTMLIndex)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This allows the autogenerated description to be used for the index page if there is no custom about info set.