### PR TITLE
Modeless dialog substitute for NewWindow dialogs on large single-window platforms

### DIFF
--- a/core/events.go
+++ b/core/events.go
@@ -400,6 +400,7 @@ func (em *Events) handlePosEvent(e events.Event) {
 			}
 			em.dragHovers = em.updateHovers(hovs, em.dragHovers, e, events.DragEnter, events.DragLeave)
 			em.dragMove(e)                              // updates sprite position
+			em.drag.AsWidget().HandleEvent(e)           // raw drag
 			em.drag.AsWidget().Send(events.DragMove, e) // usually ignored
 			e.SetHandled()
 		} else {

--- a/core/events.go
+++ b/core/events.go
@@ -249,11 +249,13 @@ func (em *Events) handlePosEvent(e events.Event) {
 		em.resetOnMouseDown()
 	case events.MouseDrag:
 		if em.spriteSlide != nil {
+			e.SetHandled()
 			em.spriteSlide.handleEvent(e)
 			em.spriteSlide.send(events.SlideMove, e)
 			return
 		}
 		if em.slide != nil {
+			e.SetHandled()
 			em.slide.AsWidget().HandleEvent(e)
 			em.slide.AsWidget().Send(events.SlideMove, e)
 			return
@@ -397,17 +399,19 @@ func (em *Events) handlePosEvent(e events.Event) {
 				}
 			}
 			em.dragHovers = em.updateHovers(hovs, em.dragHovers, e, events.DragEnter, events.DragLeave)
-			em.dragMove(e)                              // updates sprite position
-			em.drag.AsWidget().HandleEvent(e)           // raw drag
+			em.dragMove(e) // updates sprite position
+			e.SetHandled()
 			em.drag.AsWidget().Send(events.DragMove, e) // usually ignored
 		} else {
 			if em.dragPress != nil && em.dragStartCheck(e, DeviceSettings.DragStartTime, DeviceSettings.DragStartDistance) {
 				em.cancelRepeatClick()
 				em.cancelLongPress()
+				e.SetHandled()
 				em.dragPress.AsWidget().Send(events.DragStart, e)
 			} else if em.slidePress != nil && em.dragStartCheck(e, DeviceSettings.SlideStartTime, DeviceSettings.DragStartDistance) {
 				em.cancelRepeatClick()
 				em.cancelLongPress()
+				e.SetHandled()
 				em.slide = em.slidePress
 				em.slide.AsWidget().Send(events.SlideStart, e)
 			}
@@ -419,6 +423,7 @@ func (em *Events) handlePosEvent(e events.Event) {
 	case events.MouseUp:
 		em.cancelRepeatClick()
 		if em.slide != nil {
+			e.SetHandled()
 			em.slide.AsWidget().Send(events.SlideStop, e)
 			em.slide = nil
 			em.press = nil

--- a/core/events.go
+++ b/core/events.go
@@ -249,15 +249,15 @@ func (em *Events) handlePosEvent(e events.Event) {
 		em.resetOnMouseDown()
 	case events.MouseDrag:
 		if em.spriteSlide != nil {
-			e.SetHandled()
 			em.spriteSlide.handleEvent(e)
 			em.spriteSlide.send(events.SlideMove, e)
+			e.SetHandled()
 			return
 		}
 		if em.slide != nil {
-			e.SetHandled()
 			em.slide.AsWidget().HandleEvent(e)
 			em.slide.AsWidget().Send(events.SlideMove, e)
+			e.SetHandled()
 			return
 		}
 	case events.Scroll:
@@ -399,21 +399,21 @@ func (em *Events) handlePosEvent(e events.Event) {
 				}
 			}
 			em.dragHovers = em.updateHovers(hovs, em.dragHovers, e, events.DragEnter, events.DragLeave)
-			em.dragMove(e) // updates sprite position
-			e.SetHandled()
+			em.dragMove(e)                              // updates sprite position
 			em.drag.AsWidget().Send(events.DragMove, e) // usually ignored
+			e.SetHandled()
 		} else {
 			if em.dragPress != nil && em.dragStartCheck(e, DeviceSettings.DragStartTime, DeviceSettings.DragStartDistance) {
 				em.cancelRepeatClick()
 				em.cancelLongPress()
-				e.SetHandled()
 				em.dragPress.AsWidget().Send(events.DragStart, e)
+				e.SetHandled()
 			} else if em.slidePress != nil && em.dragStartCheck(e, DeviceSettings.SlideStartTime, DeviceSettings.DragStartDistance) {
 				em.cancelRepeatClick()
 				em.cancelLongPress()
-				e.SetHandled()
 				em.slide = em.slidePress
 				em.slide.AsWidget().Send(events.SlideStart, e)
+				e.SetHandled()
 			}
 		}
 		// if we already have a long press widget, we update it based on our dragging movement
@@ -423,8 +423,8 @@ func (em *Events) handlePosEvent(e events.Event) {
 	case events.MouseUp:
 		em.cancelRepeatClick()
 		if em.slide != nil {
-			e.SetHandled()
 			em.slide.AsWidget().Send(events.SlideStop, e)
+			e.SetHandled()
 			em.slide = nil
 			em.press = nil
 		}

--- a/core/handle.go
+++ b/core/handle.go
@@ -62,6 +62,7 @@ func (hl *Handle) Init() {
 	})
 
 	hl.On(events.SlideMove, func(e events.Event) {
+		e.SetHandled()
 		pos := hl.parentWidget().PointToRelPos(e.Pos())
 		hl.Pos = math32.FromPoint(pos).Dim(hl.Styles.Direction.Dim())
 		hl.SendChange(e)

--- a/core/mainstage.go
+++ b/core/mainstage.go
@@ -169,13 +169,11 @@ func (st *Stage) configMainStage() {
 	if st.NewWindow {
 		st.FullWindow = true
 	}
-	if st.NewWindow && st.Type == DialogStage && TheApp.Platform() == system.Web && st.Context != nil {
-		if st.Context.AsWidget().SizeClass() == SizeExpanded {
-			st.NewWindow = false
-			st.FullWindow = false
-			st.Modal = false
-			st.Scrim = false
-		}
+	if st.NewWindow && st.Type == DialogStage && TheApp.Platform().IsMobile() && st.Context != nil && st.Context.AsWidget().SizeClass() != SizeCompact {
+		st.NewWindow = false
+		st.FullWindow = false
+		st.Modal = false
+		st.Scrim = false
 	}
 	// if we are on mobile, we can never have new windows
 	if TheApp.Platform().IsMobile() {

--- a/core/mainstage.go
+++ b/core/mainstage.go
@@ -165,8 +165,17 @@ func (st *Stage) firstWindowStages() *stages {
 
 // configMainStage does main-stage configuration steps
 func (st *Stage) configMainStage() {
+	sc := st.Scene
 	if st.NewWindow {
 		st.FullWindow = true
+	}
+	if st.NewWindow && st.Type == DialogStage && TheApp.Platform() == system.Web && st.Context != nil {
+		if st.Context.AsWidget().SizeClass() == SizeExpanded {
+			st.NewWindow = false
+			st.FullWindow = false
+			st.Modal = false
+			st.Scrim = false
+		}
 	}
 	// if we are on mobile, we can never have new windows
 	if TheApp.Platform().IsMobile() {
@@ -175,7 +184,6 @@ func (st *Stage) configMainStage() {
 	if st.FullWindow || st.NewWindow {
 		st.Scrim = false
 	}
-	sc := st.Scene
 	sc.makeSceneBars()
 	sc.updateScene()
 }

--- a/core/mainstage.go
+++ b/core/mainstage.go
@@ -404,7 +404,7 @@ func (sm *stages) mainHandleEvent(e events.Event) {
 		if e.IsHandled() || st.Modal || st.Type == WindowStage || st.FullWindow {
 			break
 		}
-		if st.Type == DialogStage { // modal dialog, by definition
+		if st.Type == DialogStage { // modeless dialog, by definition
 			if e.HasPos() && st.Scene != nil {
 				b := st.Scene.SceneGeom.Bounds()
 				if e.WindowPos().In(b) { // don't propagate

--- a/core/mainstage.go
+++ b/core/mainstage.go
@@ -405,7 +405,7 @@ func (sm *stages) mainHandleEvent(e events.Event) {
 			break
 		}
 		if st.Type == DialogStage { // modal dialog, by definition
-			if e.HasPos() {
+			if e.HasPos() && st.Scene != nil {
 				b := st.Scene.SceneGeom.Bounds()
 				if e.WindowPos().In(b) { // don't propagate
 					break

--- a/core/mainstage.go
+++ b/core/mainstage.go
@@ -409,8 +409,6 @@ func (sm *stages) mainHandleEvent(e events.Event) {
 		if st.Type == DialogStage { // modal dialog, by definition
 			if e.HasPos() {
 				b := st.Scene.SceneGeom.Bounds()
-				b.Min.Y -= 10 // include a buffer around for dialog decoration
-				b.Max.Y += 10
 				if e.WindowPos().In(b) { // don't propagate
 					break
 				}

--- a/core/mainstage.go
+++ b/core/mainstage.go
@@ -406,5 +406,15 @@ func (sm *stages) mainHandleEvent(e events.Event) {
 		if e.IsHandled() || st.Modal || st.Type == WindowStage || st.FullWindow {
 			break
 		}
+		if st.Type == DialogStage { // modal dialog, by definition
+			if e.HasPos() {
+				b := st.Scene.SceneGeom.Bounds()
+				b.Min.Y -= 10 // include a buffer around for dialog decoration
+				b.Max.Y += 10
+				if e.WindowPos().In(b) { // don't propagate
+					break
+				}
+			}
+		}
 	}
 }

--- a/core/mainstage.go
+++ b/core/mainstage.go
@@ -169,14 +169,15 @@ func (st *Stage) configMainStage() {
 	if st.NewWindow {
 		st.FullWindow = true
 	}
-	if st.NewWindow && st.Type == DialogStage && TheApp.Platform().IsMobile() && st.Context != nil && st.Context.AsWidget().SizeClass() != SizeCompact {
-		st.NewWindow = false
-		st.FullWindow = false
-		st.Modal = false
-		st.Scrim = false
-	}
-	// if we are on mobile, we can never have new windows
 	if TheApp.Platform().IsMobile() {
+		// If we are a new window dialog on a large single-window platform,
+		// we use a modeless dialog as a substitute.
+		if st.NewWindow && st.Type == DialogStage && st.Context != nil && st.Context.AsWidget().SizeClass() != SizeCompact {
+			st.FullWindow = false
+			st.Modal = false
+			st.Scrim = false
+		}
+		// If we are on mobile, we can never have new windows.
 		st.NewWindow = false
 	}
 	if st.FullWindow || st.NewWindow {

--- a/core/style.go
+++ b/core/style.go
@@ -225,7 +225,7 @@ func styleFromTags(w Widget, tags reflect.StructTag) {
 		setFromTag(tags, "grow", func(v float32) { s.Grow.X = v })
 		setFromTag(tags, "grow-y", func(v float32) { s.Grow.Y = v })
 	})
-	if v, ok := tags.Lookup("new-window"); ok && v == "+" {
+	if tags.Get("new-window") == "+" {
 		w.AsWidget().setFlag(true, widgetValueNewWindow)
 	}
 }

--- a/core/style.go
+++ b/core/style.go
@@ -225,4 +225,7 @@ func styleFromTags(w Widget, tags reflect.StructTag) {
 		setFromTag(tags, "grow", func(v float32) { s.Grow.X = v })
 		setFromTag(tags, "grow-y", func(v float32) { s.Grow.Y = v })
 	})
+	if v, ok := tags.Lookup("new-window"); ok && v == "+" {
+		w.AsWidget().setFlag(true, widgetValueNewWindow)
+	}
 }

--- a/core/value.go
+++ b/core/value.go
@@ -116,7 +116,9 @@ func InitValueButton(v Value, allowReadOnly bool, make func(d *Body), after ...f
 	}
 	wb.OnClick(func(e events.Event) {
 		if allowReadOnly || !wb.IsReadOnly() {
-			wb.setFlag(e.HasAnyModifier(key.Shift), widgetValueNewWindow)
+			if e.HasAnyModifier(key.Shift) {
+				wb.setFlag(!wb.hasFlag(widgetValueNewWindow), widgetValueNewWindow)
+			}
 			openValueDialog(v, make, after...)
 		}
 	})

--- a/xyz/xyzcore/manip.go
+++ b/xyz/xyzcore/manip.go
@@ -218,6 +218,7 @@ func (sw *Scene) handleSelectEventsImpl(e events.Event) {
 
 func (sw *Scene) handleSlideEvents() {
 	sw.On(events.SlideMove, func(e events.Event) {
+		e.SetHandled()
 		pos := sw.Geom.ContentBBox.Min
 		e.SetLocalOff(e.LocalOff().Add(pos))
 		xy := sw.XYZ


### PR DESCRIPTION
If sizeclass is Expanded, single-window web apps support "NewWindow" desktop-like experience with modal dialogs.

Fixed the problem of events leaking through the modal dialog.  Need to be on the lookout for any regressions from these event changes -- will test more thoroughly.
