### PR TITLE
Elide file button text

### DIFF
--- a/core/filepicker.go
+++ b/core/filepicker.go
@@ -6,6 +6,7 @@ package core
 
 import (
 	"fmt"
+	"image"
 	"log"
 	"log/slog"
 	"os"
@@ -745,4 +746,15 @@ func (fb *FileButton) Init() {
 	}, func() {
 		fb.Filename = fp.SelectedFile()
 	})
+}
+
+func (fb *FileButton) WidgetTooltip(pos image.Point) (string, image.Point) {
+	if fb.Filename == "" {
+		return fb.Tooltip, fb.DefaultTooltipPos()
+	}
+	fnm := "(" + fb.Filename + ")"
+	if fb.Tooltip == "" {
+		return fnm, fb.DefaultTooltipPos()
+	}
+	return fnm + " " + fb.Tooltip, fb.DefaultTooltipPos()
 }

--- a/core/filepicker.go
+++ b/core/filepicker.go
@@ -17,6 +17,7 @@ import (
 	"github.com/fsnotify/fsnotify"
 	"github.com/mitchellh/go-homedir"
 
+	"cogentcore.org/core/base/elide"
 	"cogentcore.org/core/base/errors"
 	"cogentcore.org/core/base/fileinfo"
 	"cogentcore.org/core/colors"
@@ -731,7 +732,7 @@ func (fb *FileButton) Init() {
 		if fb.Filename == "" {
 			fb.SetText("Select file")
 		} else {
-			fb.SetText(fb.Filename)
+			fb.SetText(elide.Middle(fb.Filename, 38))
 		}
 	})
 	var fp *FilePicker

--- a/core/values.go
+++ b/core/values.go
@@ -5,6 +5,7 @@
 package core
 
 import (
+	"image"
 	"reflect"
 
 	"cogentcore.org/core/base/labels"
@@ -111,6 +112,17 @@ func (tb *TreeButton) Init() {
 	InitValueButton(tb, true, func(d *Body) {
 		makeInspector(d, tb.Tree)
 	})
+}
+
+func (tb *TreeButton) WidgetTooltip(pos image.Point) (string, image.Point) {
+	if tb.Tree == nil {
+		return tb.Tooltip, tb.DefaultTooltipPos()
+	}
+	tpa := "(" + tb.Tree.AsTree().Path() + ")"
+	if tb.Tooltip == "" {
+		return tpa, tb.DefaultTooltipPos()
+	}
+	return tpa + " " + tb.Tooltip, tb.DefaultTooltipPos()
 }
 
 // TypeChooser represents a [types.Type] value with a chooser.


### PR DESCRIPTION
Elide `FileButton` path text and add `WidgetTooltip` function for `FileButton` and `TreeButton` with the full un-elided path.

Fixes #1177 