### PR TITLE
popup sizing and positioning with a dialog "main" stage fixes.

### DIFF
--- a/core/stages.go
+++ b/core/stages.go
@@ -233,6 +233,18 @@ func (sm *stages) updateAll() (stageMods, sceneMods bool) {
 	return
 }
 
+// windowStage returns the highest level WindowStage (i.e., full window)
+func (sm *stages) windowStage() *Stage {
+	n := sm.stack.Len()
+	for i := n - 1; i >= 0; i-- {
+		st := sm.stack.ValueByIndex(i)
+		if st.Type == WindowStage {
+			return st
+		}
+	}
+	return nil
+}
+
 func (sm *stages) sendShowEvents() {
 	for _, kv := range sm.stack.Order {
 		st := kv.Value


### PR DESCRIPTION
uses the Window stage for overall size, and optimizes the positioning of the popup relative to the dialog.  also, fix the quitclean blinker logic that appears to be particularly taxed by these popups -- no need for an extra channel, just stop the ticker (probably don't even need that, but at least it shouldn't hang anymore)