### PR TITLE
disable fsnotify for file tree and file picker on all platforms for now

### DIFF
--- a/core/filepicker.go
+++ b/core/filepicker.go
@@ -123,7 +123,8 @@ func (fp *FilePicker) Init() {
 		fp.readFiles()
 
 		if fp.prevPath != fp.directory {
-			if TheApp.Platform() != system.MacOS {
+			// TODO(#424): disable for all platforms for now; causing issues
+			if false && TheApp.Platform() != system.MacOS {
 				// mac is not supported in a high-capacity fashion at this point
 				if fp.prevPath == "" {
 					fp.configWatcher()

--- a/filetree/tree.go
+++ b/filetree/tree.go
@@ -248,7 +248,7 @@ func (ft *Tree) watchUpdate(path string) {
 
 // watchPath adds given path to those watched
 func (ft *Tree) watchPath(path core.Filename) error {
-	return nil // TODO: disable for all platforms for now -- getting some issues
+	return nil // TODO(#424): disable for all platforms for now; causing issues
 	if core.TheApp.Platform() == system.MacOS {
 		return nil // mac is not supported in a high-capacity fashion at this point
 	}


### PR DESCRIPTION
It is causing some issues and doesn't really work anyway. We will get it all working in #424.