### PR TITLE
Various improvements and fixes for Cogent Mail

### DIFF
--- a/core/button.go
+++ b/core/button.go
@@ -184,6 +184,11 @@ func (bt *Button) Init() {
 		bt.Send(events.Click, e)
 	})
 
+	bt.Updater(func() {
+		// We must get the shortcuts every time since buttons
+		// may be added or removed dynamically.
+		bt.Events().getShortcutsIn(bt)
+	})
 	bt.Maker(func(p *tree.Plan) {
 		// we check if the icons are unset, not if they are nil, so
 		// that people can manually set it to [icons.None]

--- a/core/events.go
+++ b/core/events.go
@@ -1134,17 +1134,6 @@ func (em *Events) managerKeyChordEvents(e events.Event) {
 	}
 }
 
-// getShortcuts gathers all [Button]s in the [Scene] with a shortcut specified.
-// It recursively navigates [Button.Menu]s. It also gathers shortcuts from the
-// [Scene.ContextMenus].
-func (em *Events) getShortcuts() {
-	em.shortcuts = nil
-	tmps := NewScene()
-	em.scene.applyContextMenus(tmps)
-	em.getShortcutsIn(tmps)
-	em.getShortcutsIn(em.scene)
-}
-
 // getShortcutsIn gathers all [Button]s in the given parent widget with
 // a shortcut specified. It recursively navigates [Button.Menu]s.
 func (em *Events) getShortcutsIn(parent Widget) {
@@ -1161,7 +1150,7 @@ func (em *Events) getShortcutsIn(parent Widget) {
 			bt.Menu(tmps)
 			em.getShortcutsIn(tmps)
 		}
-		return tree.Continue
+		return tree.Break // there are no buttons in buttons
 	})
 }
 
@@ -1177,7 +1166,7 @@ func (em *Events) getShortcutsIn(parent Widget) {
 // processing.
 type shortcuts map[key.Chord]*Button
 
-// addShortcut adds given shortcut to given button.
+// addShortcut adds the given shortcut for the given button.
 func (em *Events) addShortcut(chord key.Chord, bt *Button) {
 	if chord == "" {
 		return

--- a/core/inlinelist.go
+++ b/core/inlinelist.go
@@ -36,8 +36,8 @@ func (il *InlineList) Init() {
 		sz := min(sl.Len(), SystemSettings.SliceInlineLength)
 		for i := 0; i < sz; i++ {
 			itxt := strconv.Itoa(i)
-			val := reflectx.UnderlyingPointer(sl.Index(i)) // deal with pointer lists
 			tree.AddNew(p, "value-"+itxt, func() Value {
+				val := reflectx.UnderlyingPointer(sl.Index(i))
 				return NewValue(val.Interface(), "")
 			}, func(w Value) {
 				wb := w.AsWidget()
@@ -53,6 +53,9 @@ func (il *InlineList) Init() {
 					})
 				}
 				wb.Updater(func() {
+					// We need to get the current value each time:
+					sl := reflectx.Underlying(reflect.ValueOf(il.Slice))
+					val := reflectx.UnderlyingPointer(sl.Index(i))
 					Bind(val.Interface(), w)
 					wb.SetReadOnly(il.IsReadOnly())
 				})

--- a/core/inlinelist.go
+++ b/core/inlinelist.go
@@ -70,19 +70,6 @@ func (il *InlineList) Init() {
 				})
 			})
 		}
-		tree.AddAt(p, "open-button", func(w *Button) {
-			w.SetIcon(icons.OpenInFull).SetType(ButtonTonal)
-			w.Tooltip = "Open in a dialog"
-			w.OnClick(func(e events.Event) {
-				d := NewBody(il.ValueTitle)
-				NewText(d).SetType(TextSupporting).SetText(il.Tooltip)
-				NewList(d).SetSlice(il.Slice).SetValueTitle(il.ValueTitle).SetReadOnly(il.IsReadOnly())
-				d.OnClose(func(e events.Event) {
-					il.UpdateChange()
-				})
-				d.RunFullDialog(il)
-			})
-		})
 	})
 }
 
@@ -135,5 +122,14 @@ func (il *InlineList) contextMenu(m *Scene, idx int) {
 	})
 	NewButton(m).SetText("Delete").SetIcon(icons.Delete).OnClick(func(e events.Event) {
 		il.DeleteAt(idx)
+	})
+	NewButton(m).SetText("Open in dialog").SetIcon(icons.OpenInNew).OnClick(func(e events.Event) {
+		d := NewBody(il.ValueTitle)
+		NewText(d).SetType(TextSupporting).SetText(il.Tooltip)
+		NewList(d).SetSlice(il.Slice).SetValueTitle(il.ValueTitle).SetReadOnly(il.IsReadOnly())
+		d.OnClose(func(e events.Event) {
+			il.UpdateChange()
+		})
+		d.RunFullDialog(il)
 	})
 }

--- a/core/inlinelist.go
+++ b/core/inlinelist.go
@@ -70,21 +70,19 @@ func (il *InlineList) Init() {
 				})
 			})
 		}
-		if !il.IsReadOnly() {
-			tree.AddAt(p, "edit-button", func(w *Button) {
-				w.SetIcon(icons.Edit).SetType(ButtonTonal)
-				w.Tooltip = "Edit list in a dialog"
-				w.OnClick(func(e events.Event) {
-					d := NewBody(il.ValueTitle)
-					NewText(d).SetType(TextSupporting).SetText(il.Tooltip)
-					NewList(d).SetSlice(il.Slice).SetValueTitle(il.ValueTitle)
-					d.OnClose(func(e events.Event) {
-						il.UpdateChange()
-					})
-					d.RunFullDialog(il)
+		tree.AddAt(p, "open-button", func(w *Button) {
+			w.SetIcon(icons.OpenInFull).SetType(ButtonTonal)
+			w.Tooltip = "Open in a dialog"
+			w.OnClick(func(e events.Event) {
+				d := NewBody(il.ValueTitle)
+				NewText(d).SetType(TextSupporting).SetText(il.Tooltip)
+				NewList(d).SetSlice(il.Slice).SetValueTitle(il.ValueTitle).SetReadOnly(il.IsReadOnly())
+				d.OnClose(func(e events.Event) {
+					il.UpdateChange()
 				})
+				d.RunFullDialog(il)
 			})
-		}
+		})
 	})
 }
 

--- a/core/inlinelist.go
+++ b/core/inlinelist.go
@@ -58,7 +58,7 @@ func (il *InlineList) Init() {
 				})
 			})
 		}
-		if !il.isArray {
+		if !il.isArray && !il.IsReadOnly() {
 			tree.AddAt(p, "add-button", func(w *Button) {
 				w.SetIcon(icons.Add).SetType(ButtonTonal)
 				w.Tooltip = "Add an element to the list"
@@ -67,19 +67,21 @@ func (il *InlineList) Init() {
 				})
 			})
 		}
-		tree.AddAt(p, "edit-button", func(w *Button) {
-			w.SetIcon(icons.Edit).SetType(ButtonTonal)
-			w.Tooltip = "Edit list in a dialog"
-			w.OnClick(func(e events.Event) {
-				d := NewBody(il.ValueTitle)
-				NewText(d).SetType(TextSupporting).SetText(il.Tooltip)
-				NewList(d).SetSlice(il.Slice).SetValueTitle(il.ValueTitle)
-				d.OnClose(func(e events.Event) {
-					il.UpdateChange()
+		if !il.IsReadOnly() {
+			tree.AddAt(p, "edit-button", func(w *Button) {
+				w.SetIcon(icons.Edit).SetType(ButtonTonal)
+				w.Tooltip = "Edit list in a dialog"
+				w.OnClick(func(e events.Event) {
+					d := NewBody(il.ValueTitle)
+					NewText(d).SetType(TextSupporting).SetText(il.Tooltip)
+					NewList(d).SetSlice(il.Slice).SetValueTitle(il.ValueTitle)
+					d.OnClose(func(e events.Event) {
+						il.UpdateChange()
+					})
+					d.RunFullDialog(il)
 				})
-				d.RunFullDialog(il)
 			})
-		})
+		}
 	})
 }
 

--- a/core/inlinelist.go
+++ b/core/inlinelist.go
@@ -31,7 +31,7 @@ func (il *InlineList) WidgetValue() any { return &il.Slice }
 func (il *InlineList) Init() {
 	il.Frame.Init()
 	il.Maker(func(p *tree.Plan) {
-		sl := reflectx.NonPointerValue(reflectx.UnderlyingPointer(reflect.ValueOf(il.Slice)))
+		sl := reflectx.Underlying(reflect.ValueOf(il.Slice))
 
 		sz := min(sl.Len(), SystemSettings.SliceInlineLength)
 		for i := 0; i < sz; i++ {

--- a/core/inlinelist_test.go
+++ b/core/inlinelist_test.go
@@ -16,10 +16,9 @@ func TestInlineList(t *testing.T) {
 
 func TestInlineListUpdate(t *testing.T) {
 	b := NewBody()
-	sl := []int{1, 2, 3}
-	il := NewInlineList(b).SetSlice(&sl)
+	il := NewInlineList(b).SetSlice(&[]int{1, 2, 3})
 	il.Update()
-	sl = []int{4, 5, 6}
+	il.SetSlice(&[]int{4, 5, 6})
 	il.Update()
 	b.AssertRender(t, "inline-list/update")
 }

--- a/core/inlinelist_test.go
+++ b/core/inlinelist_test.go
@@ -13,3 +13,13 @@ func TestInlineList(t *testing.T) {
 	NewInlineList(b).SetSlice(&[]int{1, 3, 5})
 	b.AssertRender(t, "inline-list/basic")
 }
+
+func TestInlineListUpdate(t *testing.T) {
+	b := NewBody()
+	sl := []int{1, 2, 3}
+	il := NewInlineList(b).SetSlice(&sl)
+	il.Update()
+	sl = []int{4, 5, 6}
+	il.Update()
+	b.AssertRender(t, "inline-list/update")
+}

--- a/core/keyedlist.go
+++ b/core/keyedlist.go
@@ -154,13 +154,13 @@ func (kl *KeyedList) Init() {
 					})
 				})
 			}
-			tree.AddAt(p, "edit-button", func(w *Button) {
-				w.SetIcon(icons.Edit).SetType(ButtonTonal)
-				w.Tooltip = "Edit in a dialog"
+			tree.AddAt(p, "open-button", func(w *Button) {
+				w.SetIcon(icons.OpenInFull).SetType(ButtonTonal)
+				w.Tooltip = "Open in a dialog"
 				w.OnClick(func(e events.Event) {
 					d := NewBody(kl.ValueTitle)
 					NewText(d).SetType(TextSupporting).SetText(kl.Tooltip)
-					NewKeyedList(d).SetMap(kl.Map).SetValueTitle(kl.ValueTitle)
+					NewKeyedList(d).SetMap(kl.Map).SetValueTitle(kl.ValueTitle).SetReadOnly(kl.IsReadOnly())
 					d.OnClose(func(e events.Event) {
 						kl.UpdateChange(e)
 					})

--- a/core/keyedlist.go
+++ b/core/keyedlist.go
@@ -144,27 +144,12 @@ func (kl *KeyedList) Init() {
 				})
 			}
 		}
-		if kl.Inline {
-			if !kl.IsReadOnly() {
-				tree.AddAt(p, "add-button", func(w *Button) {
-					w.SetIcon(icons.Add).SetType(ButtonTonal)
-					w.Tooltip = "Add an element"
-					w.OnClick(func(e events.Event) {
-						kl.AddItem()
-					})
-				})
-			}
-			tree.AddAt(p, "open-button", func(w *Button) {
-				w.SetIcon(icons.OpenInFull).SetType(ButtonTonal)
-				w.Tooltip = "Open in a dialog"
+		if kl.Inline && !kl.IsReadOnly() {
+			tree.AddAt(p, "add-button", func(w *Button) {
+				w.SetIcon(icons.Add).SetType(ButtonTonal)
+				w.Tooltip = "Add an element"
 				w.OnClick(func(e events.Event) {
-					d := NewBody(kl.ValueTitle)
-					NewText(d).SetType(TextSupporting).SetText(kl.Tooltip)
-					NewKeyedList(d).SetMap(kl.Map).SetValueTitle(kl.ValueTitle).SetReadOnly(kl.IsReadOnly())
-					d.OnClose(func(e events.Event) {
-						kl.UpdateChange(e)
-					})
-					d.RunFullDialog(kl)
+					kl.AddItem()
 				})
 			})
 		}
@@ -181,6 +166,17 @@ func (kl *KeyedList) contextMenu(m *Scene, keyv reflect.Value) {
 	NewButton(m).SetText("Delete").SetIcon(icons.Delete).OnClick(func(e events.Event) {
 		kl.DeleteItem(keyv)
 	})
+	if kl.Inline {
+		NewButton(m).SetText("Open in dialog").SetIcon(icons.OpenInNew).OnClick(func(e events.Event) {
+			d := NewBody(kl.ValueTitle)
+			NewText(d).SetType(TextSupporting).SetText(kl.Tooltip)
+			NewKeyedList(d).SetMap(kl.Map).SetValueTitle(kl.ValueTitle).SetReadOnly(kl.IsReadOnly())
+			d.OnClose(func(e events.Event) {
+				kl.UpdateChange(e)
+			})
+			d.RunFullDialog(kl)
+		})
+	}
 }
 
 // toggleSort toggles sorting by values vs. keys

--- a/core/scene.go
+++ b/core/scene.go
@@ -207,6 +207,16 @@ func (sc *Scene) Init() {
 		st := sm.stack.ValueByIndex(sm.stack.Len() - 2)
 		currentRenderWindow.SetStageTitle(st.Title)
 	})
+	sc.Updater(func() {
+		// At the scene level, we reset the shortcuts and add our context menu
+		// shortcuts every time. This clears the way for buttons to add their
+		// shortcuts in their own Updaters. We must get the shortcuts every time
+		// since buttons may be added or removed dynamically.
+		sc.Events.shortcuts = nil
+		tmps := NewScene()
+		sc.applyContextMenus(tmps)
+		sc.Events.getShortcutsIn(tmps)
+	})
 	if TheApp.SceneInit != nil {
 		TheApp.SceneInit(sc)
 	}

--- a/core/stages.go
+++ b/core/stages.go
@@ -258,7 +258,6 @@ func (sm *stages) sendShowEvents() {
 				sc.setFlag(true, sceneHasShown)
 				// profile.Profiling = true
 				// pr := profile.Start("send show")
-				sc.Events.getShortcuts()
 				sc.WidgetWalkDown(func(cw Widget, cwb *WidgetBase) bool {
 					cwb.Send(events.Show)
 					return tree.Continue

--- a/core/tree.go
+++ b/core/tree.go
@@ -828,19 +828,24 @@ func (tr *Tree) selectUpdate(mode events.SelectModes) bool {
 
 // sendSelectEvent sends an [events.Select] event on both this node and the root node.
 func (tr *Tree) sendSelectEvent(original ...events.Event) {
-	tr.Send(events.Select, original...)
+	if tr.This != tr.root.This {
+		tr.Send(events.Select, original...)
+	}
 	tr.root.Send(events.Select, original...)
 }
 
-// sendChangeEvent sends an [events.Change] event on the root node.
+// sendChangeEvent sends an [events.Change] event on both this node and the root node.
 func (tr *Tree) sendChangeEvent(original ...events.Event) {
+	if tr.This != tr.root.This {
+		tr.SendChange(original...)
+	}
 	tr.root.SendChange(original...)
 }
 
 // sendChangeEventReSync sends an [events.Change] event on the RootView node.
 // If SyncNode != nil, it also does a re-sync from root.
 func (tr *Tree) sendChangeEventReSync(original ...events.Event) {
-	tr.root.SendChange(original...)
+	tr.sendChangeEvent(original...)
 	if tr.root.SyncNode != nil {
 		tr.root.Resync()
 	}

--- a/core/tree.go
+++ b/core/tree.go
@@ -453,7 +453,9 @@ func (tr *Tree) Init() {
 		if tr.Icon.IsSet() {
 			tree.AddAt(p, "icon", func(w *Icon) {
 				w.Styler(func(s *styles.Style) {
-					s.Font.Size.Dp(16)
+					s.Font.Size.Dp(24)
+					s.Color = colors.Scheme.Primary.Base
+					s.Align.Self = styles.Center
 				})
 				w.Updater(func() {
 					w.SetIcon(tr.Icon)

--- a/core/tree.go
+++ b/core/tree.go
@@ -826,8 +826,9 @@ func (tr *Tree) selectUpdate(mode events.SelectModes) bool {
 	return sel
 }
 
-// sendSelectEvent sends an [events.Select] event on the root node.
+// sendSelectEvent sends an [events.Select] event on both this node and the root node.
 func (tr *Tree) sendSelectEvent(original ...events.Event) {
+	tr.Send(events.Select, original...)
 	tr.root.Send(events.Select, original...)
 }
 

--- a/core/tree.go
+++ b/core/tree.go
@@ -837,13 +837,6 @@ func (tr *Tree) sendChangeEvent(original ...events.Event) {
 	tr.root.SendChange(original...)
 }
 
-// treeChanged must be called after any structural
-// change to the [Tree] (adding or deleting nodes).
-// It calls SendChangeEvent to notify of changes.
-func (tr *Tree) treeChanged(original ...events.Event) {
-	tr.sendChangeEvent(original...)
-}
-
 // sendChangeEventReSync sends an [events.Change] event on the RootView node.
 // If SyncNode != nil, it also does a re-sync from root.
 func (tr *Tree) sendChangeEventReSync(original ...events.Event) {
@@ -1332,7 +1325,7 @@ func (tr *Tree) Cut() { //types:add
 		sn.AsTree().Delete()
 	}
 	root.Update()
-	root.treeChanged()
+	root.sendChangeEvent()
 }
 
 // Paste pastes clipboard at given node.
@@ -1401,7 +1394,7 @@ func (tr *Tree) pasteAssign(md mimedata.Mimes) {
 	tr.setScene(tr.Scene) // ensure children have scene
 	tr.Update()           // could have children
 	tr.Open()
-	tr.treeChanged()
+	tr.sendChangeEvent()
 }
 
 // pasteBefore inserts object(s) from mime data before this node.
@@ -1470,7 +1463,7 @@ func (tr *Tree) pasteAt(md mimedata.Mimes, mod events.DropMods, rel int, actNm s
 			selTv = ntv
 		}
 	}
-	tr.treeChanged()
+	tr.sendChangeEvent()
 	parent.NeedsLayout()
 	if selTv != nil {
 		selTv.SelectEvent(events.SelectOne)
@@ -1495,7 +1488,7 @@ func (tr *Tree) pasteChildren(md mimedata.Mimes, mod events.DropMods) {
 	}
 	tr.Update()
 	tr.Open()
-	tr.treeChanged()
+	tr.sendChangeEvent()
 }
 
 //////////////////////////////////////////////////////////////////////////////

--- a/core/treesync.go
+++ b/core/treesync.go
@@ -166,7 +166,7 @@ func (tr *Tree) addTreeNodes(rel, myidx int, typ *types.Type, n int) {
 	}
 	tr.Update()
 	tr.Open()
-	tr.treeChanged(nil)
+	tr.sendChangeEvent()
 	if stv != nil {
 		stv.SelectEvent(events.SelectOne)
 	}
@@ -289,7 +289,7 @@ func (tr *Tree) DeleteNode() { //types:add
 		parent := AsTree(tr.Parent)
 		tr.Delete()
 		parent.Update()
-		parent.treeChanged(nil)
+		parent.sendChangeEvent()
 	}
 }
 
@@ -321,7 +321,7 @@ func (tr *Tree) Duplicate() { //types:add
 	parent.InsertChild(nwkid, myidx+1)
 	ntv.Update()
 	parent.Update()
-	parent.treeChanged(nil)
+	parent.sendChangeEvent()
 	// ntv.SelectEvent(events.SelectOne)
 }
 
@@ -419,7 +419,7 @@ func (tr *Tree) pasteAssignSync(md mimedata.Mimes) {
 	}
 	tr.SyncNode.AsTree().CopyFrom(sl[0])
 	tr.NeedsLayout()
-	tr.sendChangeEvent(nil)
+	tr.sendChangeEvent()
 }
 
 // pasteAtSync inserts object(s) from mime data at rel position to this node.

--- a/htmlcore/handler.go
+++ b/htmlcore/handler.go
@@ -90,7 +90,7 @@ func handleElement(ctx *Context) {
 		ctx.addStyle(string(b))
 	case "style":
 		ctx.addStyle(ExtractText(ctx))
-	case "body", "main", "div", "section", "nav", "footer", "header", "ol", "ul":
+	case "body", "main", "div", "section", "nav", "footer", "header", "ol", "ul", "blockquote":
 		w := New[core.Frame](ctx)
 		ctx.NewParent = w
 		if tag == "body" {

--- a/htmlcore/html.css
+++ b/htmlcore/html.css
@@ -29,6 +29,10 @@ ol, ul {
     padding: 0dp, 0dp, 0dp, 16dp;
 }
 
+blockquote {
+    margin: 1em 40dp 1em 40dp;
+}
+
 ruby > rt {
     display: block;
     font-size: 50%;

--- a/texteditor/buffer.go
+++ b/texteditor/buffer.go
@@ -279,6 +279,10 @@ func (tb *Buffer) ConfigKnown() bool {
 	return false
 }
 
+// SetFileExt sets syntax highlighting and other parameters
+// based on the given file extension (without the . prefix),
+// for cases where an actual file with [fileinfo.FileInfo] is not
+// available.
 func (tb *Buffer) SetFileExt(ext string) *Buffer {
 	tb.Lines.SetFileExt(ext)
 	return tb

--- a/texteditor/text/lines.go
+++ b/texteditor/text/lines.go
@@ -167,7 +167,7 @@ func (ls *Lines) SetLanguage(ftyp fileinfo.Known) {
 
 // SetFileExt sets syntax highlighting and other parameters
 // based on the given file extension (without the . prefix),
-// for cases where an actual file with fileinfo.FileInfo is not
+// for cases where an actual file with [fileinfo.FileInfo] is not
 // available.
 func (ls *Lines) SetFileExt(ext string) {
 	if len(ext) == 0 {


### PR DESCRIPTION
Fixes #1027 (inline list updating), fixes shortcuts not working when the button is added after the scene is shown, improves the open button (formerly edit/view button) in inline list and inline keyed list and moves it to a context menu, improves tree change and select event handling and icon styling, improves `blockquote` element handling in htmlcore, and cleans up documentation.