### PR TITLE
Fix android packing error

### DIFF
--- a/system/driver/android/android.go
+++ b/system/driver/android/android.go
@@ -397,7 +397,7 @@ func RunInputQueue(vm, jniEnv, ctx uintptr) error {
 
 	var q *C.AInputQueue
 	for {
-		if C.ALooper_pollAll(-1, nil, nil, nil) == C.ALOOPER_POLL_WAKE {
+		if C.ALooper_pollOnce(-1, nil, nil, nil) == C.ALOOPER_POLL_WAKE {
 			select {
 			default:
 			case p := <-pending:


### PR DESCRIPTION
I ran the following command for the android platform.

```sh
core pack android --name exampleapp -android-target-sdk 32 --vv
```

But after running the command, I got an error like below. The error output is printed with the flag “very verbose”.

```
go env GOPATH
/Users/ksckaan1/go
GOMOBILE=/Users/ksckaan1/go/pkg/gomobile
WORK=/var/folders/qk/gq4r775s67g8tb81ql_gkbsc0000gn/T/gomobile-work-157298179
xcrun xcodebuild -version
Xcode 16.0
Build version 16A242d
xcrun --sdk iphoneos --find clang
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang
xcrun --sdk iphoneos --show-sdk-path
/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS18.0.sdk
xcrun --sdk iphonesimulator --find clang
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang
xcrun --sdk iphonesimulator --show-sdk-path
/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator18.0.sdk
xcrun --sdk iphonesimulator --find clang
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang
xcrun --sdk iphonesimulator --show-sdk-path
/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator18.0.sdk
xcrun --sdk macosx --find clang
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang
xcrun --sdk macosx --show-sdk-path
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX15.0.sdk
xcrun --sdk macosx --find clang
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang
xcrun --sdk macosx --show-sdk-path
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX15.0.sdk
xcrun --sdk macosx --find clang
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang
xcrun --sdk macosx --show-sdk-path
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX15.0.sdk
xcrun --sdk macosx --find clang
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang
xcrun --sdk macosx --show-sdk-path
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX15.0.sdk
generated AndroidManifest.xml:
<?xml version="1.0" encoding="utf-8"?>
<manifest
        xmlns:android="http://schemas.android.com/apk/res/android"
        package="com.Duyurubu.Dybdashboard"
        android:versionCode="1"
        android:versionName="1.0">

        <application android:label="exampleapp" android:debuggable="true">
        <activity android:name="org.golang.app.GoNativeActivity"
                android:label="exampleapp"
                android:configChanges="orientation|screenSize|keyboardHidden">
                <meta-data android:name="android.app.lib_name" android:value="exampleapp" />
                <intent-filter>
                        <action android:name="android.intent.action.MAIN" />
                        <category android:name="android.intent.category.LAUNCHER" />
                </intent-filter>
        </activity>
        </application>
</manifest>

mkdir -p "/var/folders/qk/gq4r775s67g8tb81ql_gkbsc0000gn/T/gomobile-work-157298179/lib/x86"
go env GOMODCACHE
/Users/ksckaan1/go/pkg/mod
go build -v -buildmode=c-shared -ldflags -X 'cogentcore.org/core/core.AppIcon=<svg xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewBox="0 0 1 1"><path d="M.833.675a.35.35 0 1 1 0-.35" style="stroke:#005bc0;stroke-width:.27;fill:none"/><circle cx=".53" cy=".5" r=".23" style="fill:#fbbd0e;stroke:none"/></svg>' -X cogentcore.org/core/system.CoreVersion=v0.3.4 -o /var/folders/qk/gq4r775s67g8tb81ql_gkbsc0000gn/T/gomobile-work-157298179/lib/x86/libexampleapp.so dybdashboard
cogentcore.org/core/system/driver/android
# cogentcore.org/core/system/driver/android
/Users/ksckaan1/go/pkg/mod/cogentcore.org/core@v0.3.4/system/driver/android/android.go:400:6: could not determine kind of name for C.ALooper_pollAll
rm -rf "/var/folders/qk/gq4r775s67g8tb81ql_gkbsc0000gn/T/gomobile-work-157298179"
core pack failed: failed to run "go build -v -buildmode=c-shared -ldflags -X 'cogentcore.org/core/core.AppIcon=<svg xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewBox="0 0 1 1"><path d="M.833.675a.35.35 0 1 1 0-.35" style="stroke:#005bc0;stroke-width:.27;fill:none"/><circle cx=".53" cy=".5" r=".23" style="fill:#fbbd0e;stroke:none"/></svg>' -X cogentcore.org/core/system.CoreVersion=v0.3.4 -o /var/folders/qk/gq4r775s67g8tb81ql_gkbsc0000gn/T/gomobile-work-157298179/lib/x86/libexampleapp.so dybdashboard: exit status 1"
```

i have installed SDKs 32,33,34 for android. but result is the same.

commands I tried

```sh
core pack android --name exampleapp -android-target-sdk 32 --vv
```
```sh
core pack android --name exampleapp -android-target-sdk 33 --vv
```
```sh
core pack android --name exampleapp -android-target-sdk 34 --vv
```
```sh
core pack android --name exampleapp --vv
```

After a short research I came across an issue about the same problem when trying to compile to android with Fyne.

https://github.com/fyne-io/fyne/issues/4806

Then, thinking that this problem might be caused by gomobile, I made a change in a part related to android according to the suggestions. this change is in the pr itself.

related issue

https://github.com/fyne-io/fyne/blob/d8e9fe02c9bb9e4b4c42778f5cae8ffcc43f36e2/internal/driver/mobile/app/android.go#L520

And voila, its fixed