### PR TITLE
switches do not need grow

### DIFF
--- a/core/switches.go
+++ b/core/switches.go
@@ -133,9 +133,7 @@ func (sw *Switches) Init() {
 		}
 	})
 	sw.FinalStyler(func(s *styles.Style) {
-		if s.Direction == styles.Row {
-			s.Grow.Set(1, 0)
-		} else {
+		if s.Direction != styles.Row {
 			// if we wrap, it just goes in the x direction
 			s.Wrap = false
 		}


### PR DESCRIPTION
switches in toolbar and table take up lots of space if Grow(1,0) is set, which it was. There is no reason why they should need it, and testing shows that there is no diff in other cases, so turning it off.
