### PR TITLE
Fix #1267 by removing deadlock caused by #1290

### DIFF
--- a/system/driver/base/app_multi.go
+++ b/system/driver/base/app_multi.go
@@ -124,7 +124,10 @@ func (a *AppMulti[W]) QuitClean() bool {
 	nwin := len(a.Windows)
 	for i := nwin - 1; i >= 0; i-- {
 		win := a.Windows[i]
+		// CloseReq calls RemoveWindow, which also Locks, so we must Unlock
+		a.Mu.Unlock()
 		win.CloseReq()
+		a.Mu.Lock()
 	}
 	return len(a.Windows) == 0
 }


### PR DESCRIPTION
Fix a deadlock in `system.TheApp.Quit()` caused by #1290. I tested this extensively and there are no more deadlocks or race conditions with window closing and app quitting.

Fixes #1267