### PR TITLE
Redesign reflectx pointer logic to fix panic

### DIFF
--- a/base/reflectx/pointers.go
+++ b/base/reflectx/pointers.go
@@ -30,6 +30,9 @@ func NonPointerValue(v reflect.Value) reflect.Value {
 // PointerValue returns a pointer to the given value if it is not already
 // a pointer.
 func PointerValue(v reflect.Value) reflect.Value {
+	if !v.IsValid() {
+		return v
+	}
 	if v.Kind() == reflect.Pointer {
 		return v
 	}

--- a/base/reflectx/pointers.go
+++ b/base/reflectx/pointers.go
@@ -20,9 +20,15 @@ func NonPointerType(typ reflect.Type) reflect.Type {
 }
 
 // NonPointerValue returns a non-pointer version of the given value.
+// If it encounters a nil pointer, it returns the nil pointer instead
+// of an invalid value.
 func NonPointerValue(v reflect.Value) reflect.Value {
 	for v.Kind() == reflect.Pointer {
-		v = v.Elem()
+		new := v.Elem()
+		if !new.IsValid() {
+			return v
+		}
+		v = new
 	}
 	return v
 }
@@ -67,22 +73,28 @@ func OnePointerValue(v reflect.Value) reflect.Value {
 }
 
 // Underlying returns the actual underlying version of the given value,
-// going through any pointers and interfaces.
+// going through any pointers and interfaces. If it encounters a nil
+// pointer or interface, it returns the nil pointer or interface instead of
+// an invalid value.
 func Underlying(v reflect.Value) reflect.Value {
 	if !v.IsValid() {
 		return v
 	}
 	for v.Type().Kind() == reflect.Interface || v.Type().Kind() == reflect.Pointer {
-		v = v.Elem()
-		if !v.IsValid() {
+		new := v.Elem()
+		if !new.IsValid() {
 			return v
 		}
+		v = new
 	}
 	return v
 }
 
 // UnderlyingPointer returns a pointer to the actual underlying version of the
-// given value, going through any pointers and interfaces.
+// given value, going through any pointers and interfaces. It is equivalent to
+// [OnePointerValue] of [Underlying], so if it encounters a nil pointer or
+// interface, it stops at the nil pointer or interface instead of returning
+// an invalid value.
 func UnderlyingPointer(v reflect.Value) reflect.Value {
 	if !v.IsValid() {
 		return v

--- a/base/reflectx/pointers.go
+++ b/base/reflectx/pointers.go
@@ -47,6 +47,9 @@ func PointerValue(v reflect.Value) reflect.Value {
 // OnePointerValue returns a value that is exactly one pointer away
 // from a non-pointer value.
 func OnePointerValue(v reflect.Value) reflect.Value {
+	if !v.IsValid() {
+		return v
+	}
 	if v.Kind() != reflect.Pointer {
 		if v.CanAddr() {
 			return v.Addr()

--- a/base/reflectx/pointers_test.go
+++ b/base/reflectx/pointers_test.go
@@ -48,17 +48,20 @@ func TestNonPointerValue(t *testing.T) {
 	assert.NotEqual(t, rv.Type(), NonPointerValue(reflect.ValueOf(&a)).Type())
 
 	n := (*int)(nil)
-	assert.True(t, reflect.ValueOf(n).IsValid())
-	assert.False(t, NonPointerValue(reflect.ValueOf(n)).IsValid()) // <- made invalid
+	rn := reflect.ValueOf(n)
+	assert.True(t, rn.IsValid())
+	assert.False(t, NonPointerValue(rn).IsValid()) // <- made invalid
 
 	in := myInterface(nil)
-	assert.True(t, reflect.ValueOf(&in).IsValid())
-	assert.True(t, NonPointerValue(reflect.ValueOf(&in)).IsValid())
-	assert.True(t, NonPointerValue(reflect.ValueOf(&in)).Equal(reflect.ValueOf(in)))
+	rinp := reflect.ValueOf(&in)
+	assert.True(t, rinp.IsValid())
+	assert.True(t, NonPointerValue(rinp).IsValid())
+	assert.True(t, NonPointerValue(rinp).Equal(reflect.ValueOf(in)))
 
 	an := any(nil)
-	assert.False(t, reflect.ValueOf(an).IsValid())
-	assert.False(t, NonPointerValue(reflect.ValueOf(an)).IsValid())
+	ran := reflect.ValueOf(an)
+	assert.False(t, ran.IsValid())
+	assert.False(t, NonPointerValue(ran).IsValid())
 }
 
 func TestPointerValue(t *testing.T) {
@@ -88,6 +91,7 @@ func TestPointerValue(t *testing.T) {
 
 	an := any(nil)
 	ran := reflect.ValueOf(an)
+	assert.False(t, ran.IsValid())
 	assert.False(t, PointerValue(ran).IsValid())
 }
 
@@ -119,6 +123,7 @@ func TestOnePointerValue(t *testing.T) {
 
 	an := any(nil)
 	ran := reflect.ValueOf(an)
+	assert.False(t, ran.IsValid())
 	assert.False(t, OnePointerValue(ran).IsValid())
 }
 

--- a/base/reflectx/pointers_test.go
+++ b/base/reflectx/pointers_test.go
@@ -134,6 +134,45 @@ func TestUnderlying(t *testing.T) {
 	assert.False(t, Underlying(reflect.ValueOf(an)).IsValid())
 }
 
+func TestUnderlyingPointer(t *testing.T) {
+	v := 1
+	rv := reflect.ValueOf(v)
+	assert.False(t, rv.CanAddr())
+	assert.False(t, UnderlyingPointer(reflect.ValueOf(v)).Equal(rv))
+	assert.Equal(t, reflect.TypeFor[*int](), UnderlyingPointer(reflect.ValueOf(v)).Type())
+
+	p := &v
+	rp := reflect.ValueOf(p)
+	assert.True(t, UnderlyingPointer(rp).Equal(rp))
+	assert.Equal(t, reflect.TypeFor[*int](), UnderlyingPointer(rp).Type())
+
+	assert.True(t, rp.Elem().CanAddr())
+	assert.True(t, UnderlyingPointer(rp.Elem()).Equal(rp))
+	assert.True(t, UnderlyingPointer(rp.Elem()).Equal(rp.Elem().Addr()))
+
+	pp := &p
+	rpp := reflect.ValueOf(pp)
+	assert.False(t, UnderlyingPointer(rpp).Equal(rpp))
+	assert.True(t, UnderlyingPointer(rpp).Equal(rp))
+	assert.Equal(t, reflect.TypeFor[*int](), UnderlyingPointer(rpp).Type())
+
+	a := any(v)
+	ap := &a
+	rap := reflect.ValueOf(ap)
+	// Different pointer, same type
+	assert.False(t, UnderlyingPointer(rap).Equal(rp))
+	assert.Equal(t, rp.Type(), UnderlyingPointer(rap).Type())
+	assert.Equal(t, reflect.TypeFor[*int](), UnderlyingPointer(rap).Type())
+
+	n := (*int)(nil)
+	rn := reflect.ValueOf(n)
+	assert.True(t, UnderlyingPointer(rn).Equal(rn))
+
+	an := any(nil)
+	ran := reflect.ValueOf(an)
+	assert.False(t, UnderlyingPointer(ran).IsValid())
+}
+
 type PointerTestSub struct {
 	Mbr1 string
 	Mbr2 int

--- a/base/reflectx/pointers_test.go
+++ b/base/reflectx/pointers_test.go
@@ -111,6 +111,29 @@ func TestOnePointerValue(t *testing.T) {
 	assert.False(t, OnePointerValue(ran).IsValid())
 }
 
+func TestUnderlying(t *testing.T) {
+	v := 1
+	rv := reflect.ValueOf(v)
+	assert.True(t, Underlying(reflect.ValueOf(v)).Equal(rv))
+	assert.True(t, Underlying(reflect.ValueOf(&v)).Equal(rv))
+
+	p := &v
+	assert.True(t, Underlying(reflect.ValueOf(p)).Equal(rv))
+	assert.True(t, Underlying(reflect.ValueOf(&p)).Equal(rv))
+
+	a := any(v)
+	assert.True(t, Underlying(reflect.ValueOf(a)).Equal(rv))
+	assert.Equal(t, rv.Type(), Underlying(reflect.ValueOf(a)).Type())
+	assert.True(t, Underlying(reflect.ValueOf(&a)).Equal(rv))
+	assert.Equal(t, rv.Type(), Underlying(reflect.ValueOf(&a)).Type())
+
+	n := (*int)(nil)
+	assert.False(t, Underlying(reflect.ValueOf(n)).IsValid())
+
+	an := any(nil)
+	assert.False(t, Underlying(reflect.ValueOf(an)).IsValid())
+}
+
 type PointerTestSub struct {
 	Mbr1 string
 	Mbr2 int

--- a/base/reflectx/pointers_test.go
+++ b/base/reflectx/pointers_test.go
@@ -50,7 +50,8 @@ func TestNonPointerValue(t *testing.T) {
 	n := (*int)(nil)
 	rn := reflect.ValueOf(n)
 	assert.True(t, rn.IsValid())
-	assert.False(t, NonPointerValue(rn).IsValid()) // <- made invalid
+	assert.True(t, NonPointerValue(rn).IsValid())
+	assert.True(t, NonPointerValue(rn).Equal(rn))
 
 	in := myInterface(nil)
 	rinp := reflect.ValueOf(&in)
@@ -148,12 +149,14 @@ func TestUnderlying(t *testing.T) {
 	n := (*int)(nil)
 	rn := reflect.ValueOf(n)
 	assert.True(t, rn.IsValid())
-	assert.False(t, Underlying(rn).IsValid()) // <- made invalid
+	assert.True(t, Underlying(rn).IsValid())
+	assert.True(t, Underlying(rn).Equal(rn))
 
 	in := myInterface(nil)
 	rinp := reflect.ValueOf(&in)
 	assert.True(t, rinp.IsValid())
-	assert.False(t, Underlying(rinp).IsValid()) // <- made invalid
+	assert.True(t, Underlying(rinp).IsValid())
+	assert.True(t, Underlying(rinp).Equal(rinp.Elem()))
 
 	an := any(nil)
 	ran := reflect.ValueOf(an)

--- a/base/reflectx/pointers_test.go
+++ b/base/reflectx/pointers_test.go
@@ -12,6 +12,10 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+type myInterface interface {
+	myMethod()
+}
+
 func TestNonPointerType(t *testing.T) {
 	assert.Equal(t, reflect.TypeFor[int](), NonPointerType(reflect.TypeFor[int]()))
 	assert.Equal(t, reflect.TypeFor[int](), NonPointerType(reflect.TypeFor[*int]()))
@@ -44,9 +48,16 @@ func TestNonPointerValue(t *testing.T) {
 	assert.NotEqual(t, rv.Type(), NonPointerValue(reflect.ValueOf(&a)).Type())
 
 	n := (*int)(nil)
-	assert.False(t, NonPointerValue(reflect.ValueOf(n)).IsValid())
+	assert.True(t, reflect.ValueOf(n).IsValid())
+	assert.False(t, NonPointerValue(reflect.ValueOf(n)).IsValid()) // <- made invalid
+
+	in := myInterface(nil)
+	assert.True(t, reflect.ValueOf(&in).IsValid())
+	assert.True(t, NonPointerValue(reflect.ValueOf(&in)).IsValid())
+	assert.True(t, NonPointerValue(reflect.ValueOf(&in)).Equal(reflect.ValueOf(in)))
 
 	an := any(nil)
+	assert.False(t, reflect.ValueOf(an).IsValid())
 	assert.False(t, NonPointerValue(reflect.ValueOf(an)).IsValid())
 }
 

--- a/base/reflectx/pointers_test.go
+++ b/base/reflectx/pointers_test.go
@@ -144,10 +144,19 @@ func TestUnderlying(t *testing.T) {
 	assert.Equal(t, rv.Type(), Underlying(reflect.ValueOf(&a)).Type())
 
 	n := (*int)(nil)
-	assert.False(t, Underlying(reflect.ValueOf(n)).IsValid())
+	rn := reflect.ValueOf(n)
+	assert.True(t, rn.IsValid())
+	assert.False(t, Underlying(rn).IsValid()) // <- made invalid
+
+	in := myInterface(nil)
+	rinp := reflect.ValueOf(&in)
+	assert.True(t, rinp.IsValid())
+	assert.False(t, Underlying(rinp).IsValid()) // <- made invalid
 
 	an := any(nil)
-	assert.False(t, Underlying(reflect.ValueOf(an)).IsValid())
+	ran := reflect.ValueOf(an)
+	assert.False(t, ran.IsValid())
+	assert.False(t, Underlying(ran).IsValid())
 }
 
 func TestUnderlyingPointer(t *testing.T) {

--- a/base/reflectx/pointers_test.go
+++ b/base/reflectx/pointers_test.go
@@ -8,7 +8,22 @@ import (
 	"reflect"
 	"testing"
 	"unsafe"
+
+	"github.com/stretchr/testify/assert"
 )
+
+func TestNonPointerType(t *testing.T) {
+	v := 0
+	assert.Equal(t, reflect.TypeFor[int](), NonPointerType(reflect.TypeOf(v)))
+	assert.Equal(t, reflect.TypeFor[int](), NonPointerType(reflect.TypeOf(&v)))
+	p := &v
+	assert.Equal(t, reflect.TypeFor[int](), NonPointerType(reflect.TypeOf(p)))
+	assert.Equal(t, reflect.TypeFor[int](), NonPointerType(reflect.TypeOf(&p)))
+	a := any(v)
+	assert.Equal(t, reflect.TypeFor[int](), NonPointerType(reflect.TypeOf(a)))
+	// NonPointerType cannot go through *any
+	assert.Equal(t, reflect.TypeFor[any](), NonPointerType(reflect.TypeOf(&a)))
+}
 
 type PointerTestSub struct {
 	Mbr1 string

--- a/base/reflectx/pointers_test.go
+++ b/base/reflectx/pointers_test.go
@@ -25,7 +25,7 @@ func TestNonPointerType(t *testing.T) {
 }
 
 func TestNonPointerValue(t *testing.T) {
-	v := 0
+	v := 1
 	rv := reflect.ValueOf(v)
 	assert.True(t, NonPointerValue(reflect.ValueOf(v)).Equal(rv))
 	assert.True(t, NonPointerValue(reflect.ValueOf(&v)).Equal(rv))
@@ -34,10 +34,32 @@ func TestNonPointerValue(t *testing.T) {
 	assert.True(t, NonPointerValue(reflect.ValueOf(&p)).Equal(rv))
 	a := any(v)
 	assert.True(t, NonPointerValue(reflect.ValueOf(a)).Equal(rv))
-	assert.True(t, NonPointerValue(reflect.ValueOf(a)).Type() == rv.Type())
+	assert.Equal(t, rv.Type(), NonPointerValue(reflect.ValueOf(a)).Type())
 	assert.True(t, NonPointerValue(reflect.ValueOf(&a)).Equal(rv))
 	// NonPointerValue cannot go through *any to get the true type
-	assert.False(t, NonPointerValue(reflect.ValueOf(&a)).Type() == rv.Type())
+	assert.NotEqual(t, rv.Type(), NonPointerValue(reflect.ValueOf(&a)).Type())
+}
+
+func TestPointerValue(t *testing.T) {
+	v := 1
+	rv := reflect.ValueOf(v)
+	assert.False(t, rv.CanAddr())
+	assert.False(t, PointerValue(reflect.ValueOf(v)).Equal(rv))
+	assert.Equal(t, reflect.TypeFor[*int](), PointerValue(reflect.ValueOf(v)).Type())
+
+	p := &v
+	rp := reflect.ValueOf(p)
+	assert.True(t, PointerValue(rp).Equal(rp))
+	assert.Equal(t, reflect.TypeFor[*int](), PointerValue(rp).Type())
+
+	assert.True(t, rp.Elem().CanAddr())
+	assert.True(t, PointerValue(rp.Elem()).Equal(rp))
+	assert.True(t, PointerValue(rp.Elem()).Equal(rp.Elem().Addr()))
+
+	pp := &p
+	rpp := reflect.ValueOf(pp)
+	assert.True(t, PointerValue(rpp).Equal(rpp))
+	assert.Equal(t, reflect.TypeFor[**int](), PointerValue(rpp).Type())
 }
 
 type PointerTestSub struct {

--- a/base/reflectx/pointers_test.go
+++ b/base/reflectx/pointers_test.go
@@ -80,6 +80,37 @@ func TestPointerValue(t *testing.T) {
 	assert.False(t, PointerValue(ran).IsValid())
 }
 
+func TestOnePointerValue(t *testing.T) {
+	v := 1
+	rv := reflect.ValueOf(v)
+	assert.False(t, rv.CanAddr())
+	assert.False(t, OnePointerValue(reflect.ValueOf(v)).Equal(rv))
+	assert.Equal(t, reflect.TypeFor[*int](), OnePointerValue(reflect.ValueOf(v)).Type())
+
+	p := &v
+	rp := reflect.ValueOf(p)
+	assert.True(t, OnePointerValue(rp).Equal(rp))
+	assert.Equal(t, reflect.TypeFor[*int](), OnePointerValue(rp).Type())
+
+	assert.True(t, rp.Elem().CanAddr())
+	assert.True(t, OnePointerValue(rp.Elem()).Equal(rp))
+	assert.True(t, OnePointerValue(rp.Elem()).Equal(rp.Elem().Addr()))
+
+	pp := &p
+	rpp := reflect.ValueOf(pp)
+	assert.False(t, OnePointerValue(rpp).Equal(rpp))
+	assert.True(t, OnePointerValue(rpp).Equal(rp))
+	assert.Equal(t, reflect.TypeFor[*int](), OnePointerValue(rpp).Type())
+
+	n := (*int)(nil)
+	rn := reflect.ValueOf(n)
+	assert.True(t, OnePointerValue(rn).Equal(rn))
+
+	an := any(nil)
+	ran := reflect.ValueOf(an)
+	assert.False(t, OnePointerValue(ran).IsValid())
+}
+
 type PointerTestSub struct {
 	Mbr1 string
 	Mbr2 int

--- a/base/reflectx/pointers_test.go
+++ b/base/reflectx/pointers_test.go
@@ -13,16 +13,15 @@ import (
 )
 
 func TestNonPointerType(t *testing.T) {
-	v := 0
-	assert.Equal(t, reflect.TypeFor[int](), NonPointerType(reflect.TypeOf(v)))
-	assert.Equal(t, reflect.TypeFor[int](), NonPointerType(reflect.TypeOf(&v)))
-	p := &v
-	assert.Equal(t, reflect.TypeFor[int](), NonPointerType(reflect.TypeOf(p)))
-	assert.Equal(t, reflect.TypeFor[int](), NonPointerType(reflect.TypeOf(&p)))
-	a := any(v)
-	assert.Equal(t, reflect.TypeFor[int](), NonPointerType(reflect.TypeOf(a)))
-	// NonPointerType cannot go through *any
-	assert.Equal(t, reflect.TypeFor[any](), NonPointerType(reflect.TypeOf(&a)))
+	assert.Equal(t, reflect.TypeFor[int](), NonPointerType(reflect.TypeFor[int]()))
+	assert.Equal(t, reflect.TypeFor[int](), NonPointerType(reflect.TypeFor[*int]()))
+	assert.Equal(t, reflect.TypeFor[int](), NonPointerType(reflect.TypeFor[**int]()))
+	assert.Equal(t, reflect.TypeFor[int](), NonPointerType(reflect.TypeFor[***int]()))
+
+	assert.Equal(t, reflect.TypeFor[any](), NonPointerType(reflect.TypeFor[any]()))
+	assert.Equal(t, reflect.TypeFor[any](), NonPointerType(reflect.TypeFor[*any]()))
+	assert.Equal(t, reflect.TypeFor[any](), NonPointerType(reflect.TypeFor[**any]()))
+	assert.Equal(t, reflect.TypeFor[any](), NonPointerType(reflect.TypeFor[***any]()))
 }
 
 type PointerTestSub struct {

--- a/base/reflectx/pointers_test.go
+++ b/base/reflectx/pointers_test.go
@@ -24,6 +24,22 @@ func TestNonPointerType(t *testing.T) {
 	assert.Equal(t, reflect.TypeFor[any](), NonPointerType(reflect.TypeFor[***any]()))
 }
 
+func TestNonPointerValue(t *testing.T) {
+	v := 0
+	rv := reflect.ValueOf(v)
+	assert.True(t, NonPointerValue(reflect.ValueOf(v)).Equal(rv))
+	assert.True(t, NonPointerValue(reflect.ValueOf(&v)).Equal(rv))
+	p := &v
+	assert.True(t, NonPointerValue(reflect.ValueOf(p)).Equal(rv))
+	assert.True(t, NonPointerValue(reflect.ValueOf(&p)).Equal(rv))
+	a := any(v)
+	assert.True(t, NonPointerValue(reflect.ValueOf(a)).Equal(rv))
+	assert.True(t, NonPointerValue(reflect.ValueOf(a)).Type() == rv.Type())
+	assert.True(t, NonPointerValue(reflect.ValueOf(&a)).Equal(rv))
+	// NonPointerValue cannot go through *any to get the true type
+	assert.False(t, NonPointerValue(reflect.ValueOf(&a)).Type() == rv.Type())
+}
+
 type PointerTestSub struct {
 	Mbr1 string
 	Mbr2 int

--- a/base/reflectx/pointers_test.go
+++ b/base/reflectx/pointers_test.go
@@ -22,6 +22,8 @@ func TestNonPointerType(t *testing.T) {
 	assert.Equal(t, reflect.TypeFor[any](), NonPointerType(reflect.TypeFor[*any]()))
 	assert.Equal(t, reflect.TypeFor[any](), NonPointerType(reflect.TypeFor[**any]()))
 	assert.Equal(t, reflect.TypeFor[any](), NonPointerType(reflect.TypeFor[***any]()))
+
+	assert.Equal(t, nil, NonPointerType(reflect.TypeOf(nil)))
 }
 
 func TestNonPointerValue(t *testing.T) {
@@ -29,15 +31,23 @@ func TestNonPointerValue(t *testing.T) {
 	rv := reflect.ValueOf(v)
 	assert.True(t, NonPointerValue(reflect.ValueOf(v)).Equal(rv))
 	assert.True(t, NonPointerValue(reflect.ValueOf(&v)).Equal(rv))
+
 	p := &v
 	assert.True(t, NonPointerValue(reflect.ValueOf(p)).Equal(rv))
 	assert.True(t, NonPointerValue(reflect.ValueOf(&p)).Equal(rv))
+
 	a := any(v)
 	assert.True(t, NonPointerValue(reflect.ValueOf(a)).Equal(rv))
 	assert.Equal(t, rv.Type(), NonPointerValue(reflect.ValueOf(a)).Type())
 	assert.True(t, NonPointerValue(reflect.ValueOf(&a)).Equal(rv))
 	// NonPointerValue cannot go through *any to get the true type
 	assert.NotEqual(t, rv.Type(), NonPointerValue(reflect.ValueOf(&a)).Type())
+
+	n := (*int)(nil)
+	assert.False(t, NonPointerValue(reflect.ValueOf(n)).IsValid())
+
+	an := any(nil)
+	assert.False(t, NonPointerValue(reflect.ValueOf(an)).IsValid())
 }
 
 func TestPointerValue(t *testing.T) {
@@ -60,6 +70,14 @@ func TestPointerValue(t *testing.T) {
 	rpp := reflect.ValueOf(pp)
 	assert.True(t, PointerValue(rpp).Equal(rpp))
 	assert.Equal(t, reflect.TypeFor[**int](), PointerValue(rpp).Type())
+
+	n := (*int)(nil)
+	rn := reflect.ValueOf(n)
+	assert.True(t, PointerValue(rn).Equal(rn))
+
+	an := any(nil)
+	ran := reflect.ValueOf(an)
+	assert.False(t, PointerValue(ran).IsValid())
 }
 
 type PointerTestSub struct {

--- a/base/reflectx/pointers_test.go
+++ b/base/reflectx/pointers_test.go
@@ -119,6 +119,8 @@ func TestOnePointerValue(t *testing.T) {
 
 	n := (*int)(nil)
 	rn := reflect.ValueOf(n)
+	assert.True(t, rn.IsValid())
+	assert.True(t, OnePointerValue(rn).IsValid())
 	assert.True(t, OnePointerValue(rn).Equal(rn))
 
 	an := any(nil)
@@ -191,10 +193,13 @@ func TestUnderlyingPointer(t *testing.T) {
 
 	n := (*int)(nil)
 	rn := reflect.ValueOf(n)
+	assert.True(t, rn.IsValid())
+	assert.True(t, UnderlyingPointer(rn).IsValid())
 	assert.True(t, UnderlyingPointer(rn).Equal(rn))
 
 	an := any(nil)
 	ran := reflect.ValueOf(an)
+	assert.False(t, ran.IsValid())
 	assert.False(t, UnderlyingPointer(ran).IsValid())
 }
 

--- a/base/reflectx/pointers_test.go
+++ b/base/reflectx/pointers_test.go
@@ -173,6 +173,26 @@ func TestUnderlyingPointer(t *testing.T) {
 	assert.False(t, UnderlyingPointer(ran).IsValid())
 }
 
+func TestNonNilNew(t *testing.T) {
+	n0 := NonNilNew(reflect.TypeFor[int]())
+	assert.Equal(t, reflect.TypeFor[*int](), n0.Type())
+	assert.False(t, n0.IsNil())
+	assert.Equal(t, 0, n0.Elem().Interface())
+
+	n1 := NonNilNew(reflect.TypeFor[*int]())
+	assert.Equal(t, reflect.TypeFor[**int](), n1.Type())
+	assert.False(t, n1.IsNil())
+	assert.False(t, n1.Elem().IsNil())
+	assert.Equal(t, 0, n1.Elem().Elem().Interface())
+
+	n2 := NonNilNew(reflect.TypeFor[**int]())
+	assert.Equal(t, reflect.TypeFor[***int](), n2.Type())
+	assert.False(t, n2.IsNil())
+	assert.False(t, n2.Elem().IsNil())
+	assert.False(t, n2.Elem().Elem().IsNil())
+	assert.Equal(t, 0, n2.Elem().Elem().Elem().Interface())
+}
+
 type PointerTestSub struct {
 	Mbr1 string
 	Mbr2 int

--- a/base/reflectx/structs.go
+++ b/base/reflectx/structs.go
@@ -158,8 +158,8 @@ type ShouldSaver interface {
 func NonDefaultFields(v any) map[string]any {
 	res := map[string]any{}
 
-	rv := NonPointerValue(reflect.ValueOf(v))
-	if !rv.IsValid() {
+	rv := Underlying(reflect.ValueOf(v))
+	if IsNil(rv) {
 		return nil
 	}
 	rt := rv.Type()

--- a/base/reflectx/structs.go
+++ b/base/reflectx/structs.go
@@ -103,11 +103,8 @@ func ValueIsDefault(fv reflect.Value, def string) bool {
 // SetFromDefaultTags sets the values of fields in the given struct based on
 // `default:` default value struct field tags.
 func SetFromDefaultTags(v any) error {
-	if IsNil(v) {
-		return nil
-	}
 	ov := reflect.ValueOf(v)
-	if ov.Kind() == reflect.Pointer && ov.IsNil() {
+	if IsNil(ov) {
 		return nil
 	}
 	val := NonPointerValue(ov)

--- a/base/reflectx/structs.go
+++ b/base/reflectx/structs.go
@@ -103,7 +103,7 @@ func ValueIsDefault(fv reflect.Value, def string) bool {
 // SetFromDefaultTags sets the values of fields in the given struct based on
 // `default:` default value struct field tags.
 func SetFromDefaultTags(v any) error {
-	if AnyIsNil(v) {
+	if IsNil(v) {
 		return nil
 	}
 	ov := reflect.ValueOf(v)

--- a/base/reflectx/values.go
+++ b/base/reflectx/values.go
@@ -21,17 +21,16 @@ import (
 	"cogentcore.org/core/enums"
 )
 
-// IsNil checks if an interface value is nil. The interface itself
-// could be nil, or the value pointed to by the interface could be nil.
-// This safely checks both.
-func IsNil(v any) bool {
-	if v == nil {
+// IsNil returns whether the given value is nil or invalid.
+// If it is a non-nillable type, it does not check whether
+// it is nil to avoid panics.
+func IsNil(v reflect.Value) bool {
+	if !v.IsValid() {
 		return true
 	}
-	rv := reflect.ValueOf(v)
-	vk := rv.Kind()
-	if vk == reflect.Pointer || vk == reflect.Interface || vk == reflect.Map || vk == reflect.Slice || vk == reflect.Func || vk == reflect.Chan {
-		return rv.IsNil()
+	switch v.Kind() {
+	case reflect.Pointer, reflect.Interface, reflect.Map, reflect.Slice, reflect.Func, reflect.Chan:
+		return v.IsNil()
 	}
 	return false
 }
@@ -178,24 +177,24 @@ func ToBool(v any) (bool, error) {
 	}
 
 	// then fall back on reflection
-	if IsNil(v) {
+	uv := Underlying(reflect.ValueOf(v))
+	if IsNil(uv) {
 		return false, fmt.Errorf("got nil value of type %T", v)
 	}
-	npv := Underlying(reflect.ValueOf(v))
-	vk := npv.Kind()
+	vk := uv.Kind()
 	switch {
 	case vk >= reflect.Int && vk <= reflect.Int64:
-		return (npv.Int() != 0), nil
+		return (uv.Int() != 0), nil
 	case vk >= reflect.Uint && vk <= reflect.Uint64:
-		return (npv.Uint() != 0), nil
+		return (uv.Uint() != 0), nil
 	case vk == reflect.Bool:
-		return npv.Bool(), nil
+		return uv.Bool(), nil
 	case vk >= reflect.Float32 && vk <= reflect.Float64:
-		return (npv.Float() != 0.0), nil
+		return (uv.Float() != 0.0), nil
 	case vk >= reflect.Complex64 && vk <= reflect.Complex128:
-		return (real(npv.Complex()) != 0.0), nil
+		return (real(uv.Complex()) != 0.0), nil
 	case vk == reflect.String:
-		r, err := strconv.ParseBool(npv.String())
+		r, err := strconv.ParseBool(uv.String())
 		if err != nil {
 			return false, err
 		}
@@ -335,27 +334,27 @@ func ToInt(v any) (int64, error) {
 	}
 
 	// then fall back on reflection
-	if IsNil(v) {
+	uv := Underlying(reflect.ValueOf(v))
+	if IsNil(uv) {
 		return 0, fmt.Errorf("got nil value of type %T", v)
 	}
-	npv := Underlying(reflect.ValueOf(v))
-	vk := npv.Kind()
+	vk := uv.Kind()
 	switch {
 	case vk >= reflect.Int && vk <= reflect.Int64:
-		return npv.Int(), nil
+		return uv.Int(), nil
 	case vk >= reflect.Uint && vk <= reflect.Uint64:
-		return int64(npv.Uint()), nil
+		return int64(uv.Uint()), nil
 	case vk == reflect.Bool:
-		if npv.Bool() {
+		if uv.Bool() {
 			return 1, nil
 		}
 		return 0, nil
 	case vk >= reflect.Float32 && vk <= reflect.Float64:
-		return int64(npv.Float()), nil
+		return int64(uv.Float()), nil
 	case vk >= reflect.Complex64 && vk <= reflect.Complex128:
-		return int64(real(npv.Complex())), nil
+		return int64(real(uv.Complex())), nil
 	case vk == reflect.String:
-		r, err := strconv.ParseInt(npv.String(), 0, 64)
+		r, err := strconv.ParseInt(uv.String(), 0, 64)
 		if err != nil {
 			return 0, err
 		}
@@ -492,27 +491,27 @@ func ToFloat(v any) (float64, error) {
 	}
 
 	// then fall back on reflection
-	if IsNil(v) {
+	uv := Underlying(reflect.ValueOf(v))
+	if IsNil(uv) {
 		return 0, fmt.Errorf("got nil value of type %T", v)
 	}
-	npv := Underlying(reflect.ValueOf(v))
-	vk := npv.Kind()
+	vk := uv.Kind()
 	switch {
 	case vk >= reflect.Int && vk <= reflect.Int64:
-		return float64(npv.Int()), nil
+		return float64(uv.Int()), nil
 	case vk >= reflect.Uint && vk <= reflect.Uint64:
-		return float64(npv.Uint()), nil
+		return float64(uv.Uint()), nil
 	case vk == reflect.Bool:
-		if npv.Bool() {
+		if uv.Bool() {
 			return 1, nil
 		}
 		return 0, nil
 	case vk >= reflect.Float32 && vk <= reflect.Float64:
-		return npv.Float(), nil
+		return uv.Float(), nil
 	case vk >= reflect.Complex64 && vk <= reflect.Complex128:
-		return real(npv.Complex()), nil
+		return real(uv.Complex()), nil
 	case vk == reflect.String:
-		r, err := strconv.ParseFloat(npv.String(), 64)
+		r, err := strconv.ParseFloat(uv.String(), 64)
 		if err != nil {
 			return 0, err
 		}
@@ -649,27 +648,27 @@ func ToFloat32(v any) (float32, error) {
 	}
 
 	// then fall back on reflection
-	if IsNil(v) {
+	uv := Underlying(reflect.ValueOf(v))
+	if IsNil(uv) {
 		return 0, fmt.Errorf("got nil value of type %T", v)
 	}
-	npv := Underlying(reflect.ValueOf(v))
-	vk := npv.Kind()
+	vk := uv.Kind()
 	switch {
 	case vk >= reflect.Int && vk <= reflect.Int64:
-		return float32(npv.Int()), nil
+		return float32(uv.Int()), nil
 	case vk >= reflect.Uint && vk <= reflect.Uint64:
-		return float32(npv.Uint()), nil
+		return float32(uv.Uint()), nil
 	case vk == reflect.Bool:
-		if npv.Bool() {
+		if uv.Bool() {
 			return 1, nil
 		}
 		return 0, nil
 	case vk >= reflect.Float32 && vk <= reflect.Float64:
-		return float32(npv.Float()), nil
+		return float32(uv.Float()), nil
 	case vk >= reflect.Complex64 && vk <= reflect.Complex128:
-		return float32(real(npv.Complex())), nil
+		return float32(real(uv.Complex())), nil
 	case vk == reflect.String:
-		r, err := strconv.ParseFloat(npv.String(), 32)
+		r, err := strconv.ParseFloat(uv.String(), 32)
 		if err != nil {
 			return 0, err
 		}
@@ -689,9 +688,6 @@ func ToFloat32(v any) (float32, error) {
 // pointers, and byte is converted as string(byte), not the decimal representation.
 func ToString(v any) string {
 	nilstr := "nil"
-	if IsNil(v) {
-		return nilstr
-	}
 	switch vt := v.(type) {
 	case string:
 		return vt
@@ -836,26 +832,26 @@ func ToString(v any) string {
 	}
 
 	// then fall back on reflection
-	if IsNil(v) {
+	uv := Underlying(reflect.ValueOf(v))
+	if IsNil(uv) {
 		return nilstr
 	}
-	npv := Underlying(reflect.ValueOf(v))
-	vk := npv.Kind()
+	vk := uv.Kind()
 	switch {
 	case vk >= reflect.Int && vk <= reflect.Int64:
-		return strconv.FormatInt(npv.Int(), 10)
+		return strconv.FormatInt(uv.Int(), 10)
 	case vk >= reflect.Uint && vk <= reflect.Uint64:
-		return strconv.FormatUint(npv.Uint(), 10)
+		return strconv.FormatUint(uv.Uint(), 10)
 	case vk == reflect.Bool:
-		return strconv.FormatBool(npv.Bool())
+		return strconv.FormatBool(uv.Bool())
 	case vk >= reflect.Float32 && vk <= reflect.Float64:
-		return strconv.FormatFloat(npv.Float(), 'G', -1, 64)
+		return strconv.FormatFloat(uv.Float(), 'G', -1, 64)
 	case vk >= reflect.Complex64 && vk <= reflect.Complex128:
-		cv := npv.Complex()
+		cv := uv.Complex()
 		rv := strconv.FormatFloat(real(cv), 'G', -1, 64) + "," + strconv.FormatFloat(imag(cv), 'G', -1, 64)
 		return rv
 	case vk == reflect.String:
-		return npv.String()
+		return uv.String()
 	case vk == reflect.Slice:
 		eltyp := SliceElementType(v)
 		if eltyp.Kind() == reflect.Uint8 { // []byte
@@ -936,10 +932,10 @@ func ToStringPrec(v any, prec int) string {
 // Note that maps are not reset prior to setting, whereas slices are
 // set to be fully equivalent to the source slice.
 func SetRobust(to, from any) error {
-	if IsNil(to) {
+	v := reflect.ValueOf(to)
+	if IsNil(v) {
 		return fmt.Errorf("got nil destination value")
 	}
-	v := reflect.ValueOf(to)
 	pointer := UnderlyingPointer(v)
 	ti := pointer.Interface()
 

--- a/base/reflectx/values.go
+++ b/base/reflectx/values.go
@@ -21,10 +21,10 @@ import (
 	"cogentcore.org/core/enums"
 )
 
-// AnyIsNil checks if an interface value is nil. The interface itself
+// IsNil checks if an interface value is nil. The interface itself
 // could be nil, or the value pointed to by the interface could be nil.
 // This safely checks both.
-func AnyIsNil(v any) bool {
+func IsNil(v any) bool {
 	if v == nil {
 		return true
 	}
@@ -178,7 +178,7 @@ func ToBool(v any) (bool, error) {
 	}
 
 	// then fall back on reflection
-	if AnyIsNil(v) {
+	if IsNil(v) {
 		return false, fmt.Errorf("got nil value of type %T", v)
 	}
 	npv := Underlying(reflect.ValueOf(v))
@@ -335,7 +335,7 @@ func ToInt(v any) (int64, error) {
 	}
 
 	// then fall back on reflection
-	if AnyIsNil(v) {
+	if IsNil(v) {
 		return 0, fmt.Errorf("got nil value of type %T", v)
 	}
 	npv := Underlying(reflect.ValueOf(v))
@@ -492,7 +492,7 @@ func ToFloat(v any) (float64, error) {
 	}
 
 	// then fall back on reflection
-	if AnyIsNil(v) {
+	if IsNil(v) {
 		return 0, fmt.Errorf("got nil value of type %T", v)
 	}
 	npv := Underlying(reflect.ValueOf(v))
@@ -649,7 +649,7 @@ func ToFloat32(v any) (float32, error) {
 	}
 
 	// then fall back on reflection
-	if AnyIsNil(v) {
+	if IsNil(v) {
 		return 0, fmt.Errorf("got nil value of type %T", v)
 	}
 	npv := Underlying(reflect.ValueOf(v))
@@ -689,7 +689,7 @@ func ToFloat32(v any) (float32, error) {
 // pointers, and byte is converted as string(byte), not the decimal representation.
 func ToString(v any) string {
 	nilstr := "nil"
-	if AnyIsNil(v) {
+	if IsNil(v) {
 		return nilstr
 	}
 	switch vt := v.(type) {
@@ -836,7 +836,7 @@ func ToString(v any) string {
 	}
 
 	// then fall back on reflection
-	if AnyIsNil(v) {
+	if IsNil(v) {
 		return nilstr
 	}
 	npv := Underlying(reflect.ValueOf(v))
@@ -936,7 +936,7 @@ func ToStringPrec(v any, prec int) string {
 // Note that maps are not reset prior to setting, whereas slices are
 // set to be fully equivalent to the source slice.
 func SetRobust(to, from any) error {
-	if AnyIsNil(to) {
+	if IsNil(to) {
 		return fmt.Errorf("got nil destination value")
 	}
 	v := reflect.ValueOf(to)

--- a/base/reflectx/values.go
+++ b/base/reflectx/values.go
@@ -688,6 +688,12 @@ func ToFloat32(v any) (float32, error) {
 // pointers, and byte is converted as string(byte), not the decimal representation.
 func ToString(v any) string {
 	nilstr := "nil"
+	// TODO: this reflection is unideal for performance, but we need it to prevent panics,
+	// so this whole "greatest efficiency" type switch is kind of pointless.
+	rv := reflect.ValueOf(v)
+	if IsNil(rv) {
+		return nilstr
+	}
 	switch vt := v.(type) {
 	case string:
 		return vt
@@ -832,7 +838,7 @@ func ToString(v any) string {
 	}
 
 	// then fall back on reflection
-	uv := Underlying(reflect.ValueOf(v))
+	uv := Underlying(rv)
 	if IsNil(uv) {
 		return nilstr
 	}

--- a/base/reflectx/values_test.go
+++ b/base/reflectx/values_test.go
@@ -42,11 +42,14 @@ func InitC() {
 	c.Mbr6 = 6
 }
 
-func AFun(aa any) bool {
-	return IsNil(reflect.ValueOf(aa))
+func isNil(v any) bool {
+	return IsNil(reflect.ValueOf(v))
 }
 
-func TestAnyIsNil(t *testing.T) {
+func TestIsNil(t *testing.T) {
+	assert.False(t, IsNil(reflect.ValueOf(0)))
+	assert.True(t, IsNil(reflect.ValueOf((*int)(nil))))
+
 	ai := any(a)
 
 	assert.False(t, IsNil(reflect.ValueOf(ai)))
@@ -55,8 +58,9 @@ func TestAnyIsNil(t *testing.T) {
 	api := any(ap)
 
 	assert.True(t, IsNil(reflect.ValueOf(api)))
-	assert.True(t, AFun(ap))
-	assert.False(t, AFun(&a))
+	assert.True(t, isNil(ap))
+	assert.False(t, isNil(&a))
+	assert.False(t, isNil(&ap))
 }
 
 func TestConverts(t *testing.T) {

--- a/base/reflectx/values_test.go
+++ b/base/reflectx/values_test.go
@@ -42,20 +42,20 @@ func InitC() {
 }
 
 func AFun(aa any) bool {
-	return AnyIsNil(aa)
+	return IsNil(aa)
 }
 
 func TestAnyIsNil(t *testing.T) {
 	ai := any(a)
 
-	if AnyIsNil(ai) != false {
+	if IsNil(ai) != false {
 		t.Errorf("should be non-nil: %v\n", ai)
 	}
 
 	var ap *A
 	api := any(ap)
 
-	if AnyIsNil(api) != true {
+	if IsNil(api) != true {
 		t.Errorf("should be nil: %v\n", api)
 	}
 

--- a/base/reflectx/values_test.go
+++ b/base/reflectx/values_test.go
@@ -6,6 +6,7 @@ package reflectx
 
 import (
 	"fmt"
+	"reflect"
 	"testing"
 
 	"cogentcore.org/core/base/reflectx/testdata"
@@ -42,31 +43,20 @@ func InitC() {
 }
 
 func AFun(aa any) bool {
-	return IsNil(aa)
+	return IsNil(reflect.ValueOf(aa))
 }
 
 func TestAnyIsNil(t *testing.T) {
 	ai := any(a)
 
-	if IsNil(ai) != false {
-		t.Errorf("should be non-nil: %v\n", ai)
-	}
+	assert.False(t, IsNil(reflect.ValueOf(ai)))
 
 	var ap *A
 	api := any(ap)
 
-	if IsNil(api) != true {
-		t.Errorf("should be nil: %v\n", api)
-	}
-
-	if AFun(ap) != true {
-		t.Errorf("should be nil: %v\n", ap)
-	}
-
-	if AFun(&a) != false {
-		t.Errorf("should be non-nil: %v\n", &a)
-	}
-
+	assert.True(t, IsNil(reflect.ValueOf(api)))
+	assert.True(t, AFun(ap))
+	assert.False(t, AFun(&a))
 }
 
 func TestConverts(t *testing.T) {

--- a/cli/field.go
+++ b/cli/field.go
@@ -60,11 +60,8 @@ func addFields(obj any, allFields *fields, cmd string) {
 // the "cmd" struct tag, as the user already knows what command they are
 // running, so they do not need that duplicated specificity for every flag.
 func addFieldsImpl(obj any, path string, cmdPath string, allFields *fields, usedNames map[string]*field, cmd string) {
-	if reflectx.IsNil(obj) {
-		return
-	}
 	ov := reflect.ValueOf(obj)
-	if ov.Kind() == reflect.Pointer && ov.IsNil() {
+	if reflectx.IsNil(ov) {
 		return
 	}
 	val := reflectx.NonPointerValue(ov)

--- a/cli/field.go
+++ b/cli/field.go
@@ -60,7 +60,7 @@ func addFields(obj any, allFields *fields, cmd string) {
 // the "cmd" struct tag, as the user already knows what command they are
 // running, so they do not need that duplicated specificity for every flag.
 func addFieldsImpl(obj any, path string, cmdPath string, allFields *fields, usedNames map[string]*field, cmd string) {
-	if reflectx.AnyIsNil(obj) {
+	if reflectx.IsNil(obj) {
 		return
 	}
 	ov := reflect.ValueOf(obj)

--- a/core/dialog.go
+++ b/core/dialog.go
@@ -198,7 +198,7 @@ func (bd *Body) dialogStyles() {
 // nonNilContext returns a non-nil context widget, falling back on the top
 // scene of the current window.
 func nonNilContext(ctx Widget) Widget {
-	if !reflectx.AnyIsNil(ctx) {
+	if !reflectx.IsNil(ctx) {
 		return ctx
 	}
 	return currentRenderWindow.mains.top().Scene

--- a/core/dialog.go
+++ b/core/dialog.go
@@ -6,6 +6,7 @@ package core
 
 import (
 	"log/slog"
+	"reflect"
 
 	"cogentcore.org/core/base/errors"
 	"cogentcore.org/core/base/reflectx"
@@ -198,7 +199,7 @@ func (bd *Body) dialogStyles() {
 // nonNilContext returns a non-nil context widget, falling back on the top
 // scene of the current window.
 func nonNilContext(ctx Widget) Widget {
-	if !reflectx.IsNil(ctx) {
+	if !reflectx.IsNil(reflect.ValueOf(ctx)) {
 		return ctx
 	}
 	return currentRenderWindow.mains.top().Scene

--- a/core/form.go
+++ b/core/form.go
@@ -129,7 +129,7 @@ func (fm *Form) Init() {
 	})
 
 	fm.Maker(func(p *tree.Plan) {
-		if reflectx.AnyIsNil(fm.Struct) {
+		if reflectx.IsNil(fm.Struct) {
 			return
 		}
 

--- a/core/form.go
+++ b/core/form.go
@@ -129,7 +129,7 @@ func (fm *Form) Init() {
 	})
 
 	fm.Maker(func(p *tree.Plan) {
-		if reflectx.IsNil(fm.Struct) {
+		if reflectx.IsNil(reflect.ValueOf(fm.Struct)) {
 			return
 		}
 

--- a/core/inlinelist.go
+++ b/core/inlinelist.go
@@ -76,7 +76,7 @@ func (il *InlineList) Init() {
 // SetSlice sets the source slice that we are viewing.
 // It rebuilds the children to represent this slice.
 func (il *InlineList) SetSlice(sl any) *InlineList {
-	if reflectx.IsNil(sl) {
+	if reflectx.IsNil(reflect.ValueOf(sl)) {
 		il.Slice = nil
 		return il
 	}

--- a/core/inlinelist.go
+++ b/core/inlinelist.go
@@ -76,7 +76,7 @@ func (il *InlineList) Init() {
 // SetSlice sets the source slice that we are viewing.
 // It rebuilds the children to represent this slice.
 func (il *InlineList) SetSlice(sl any) *InlineList {
-	if reflectx.AnyIsNil(sl) {
+	if reflectx.IsNil(sl) {
 		il.Slice = nil
 		return il
 	}

--- a/core/keyedlist.go
+++ b/core/keyedlist.go
@@ -50,10 +50,10 @@ func (kl *KeyedList) Init() {
 	})
 
 	kl.Maker(func(p *tree.Plan) {
-		if reflectx.IsNil(kl.Map) {
+		mapv := reflectx.Underlying(reflect.ValueOf(kl.Map))
+		if reflectx.IsNil(mapv) {
 			return
 		}
-		mapv := reflectx.Underlying(reflect.ValueOf(kl.Map))
 
 		kl.ncols = 2
 		typeAny := false
@@ -187,7 +187,7 @@ func (kl *KeyedList) toggleSort() {
 
 // AddItem adds a new key-value item to the map.
 func (kl *KeyedList) AddItem() {
-	if reflectx.IsNil(kl.Map) {
+	if reflectx.IsNil(reflect.ValueOf(kl.Map)) {
 		return
 	}
 	reflectx.MapAdd(kl.Map)
@@ -196,7 +196,7 @@ func (kl *KeyedList) AddItem() {
 
 // DeleteItem deletes a key-value item from the map.
 func (kl *KeyedList) DeleteItem(key reflect.Value) {
-	if reflectx.IsNil(kl.Map) {
+	if reflectx.IsNil(reflect.ValueOf(kl.Map)) {
 		return
 	}
 	reflectx.MapDelete(kl.Map, reflectx.NonPointerValue(key))
@@ -204,7 +204,7 @@ func (kl *KeyedList) DeleteItem(key reflect.Value) {
 }
 
 func (kl *KeyedList) MakeToolbar(p *tree.Plan) {
-	if reflectx.IsNil(kl.Map) {
+	if reflectx.IsNil(reflect.ValueOf(kl.Map)) {
 		return
 	}
 	tree.Add(p, func(w *Button) {

--- a/core/keyedlist.go
+++ b/core/keyedlist.go
@@ -50,7 +50,7 @@ func (kl *KeyedList) Init() {
 	})
 
 	kl.Maker(func(p *tree.Plan) {
-		if reflectx.AnyIsNil(kl.Map) {
+		if reflectx.IsNil(kl.Map) {
 			return
 		}
 		mapv := reflectx.Underlying(reflect.ValueOf(kl.Map))
@@ -187,7 +187,7 @@ func (kl *KeyedList) toggleSort() {
 
 // AddItem adds a new key-value item to the map.
 func (kl *KeyedList) AddItem() {
-	if reflectx.AnyIsNil(kl.Map) {
+	if reflectx.IsNil(kl.Map) {
 		return
 	}
 	reflectx.MapAdd(kl.Map)
@@ -196,7 +196,7 @@ func (kl *KeyedList) AddItem() {
 
 // DeleteItem deletes a key-value item from the map.
 func (kl *KeyedList) DeleteItem(key reflect.Value) {
-	if reflectx.AnyIsNil(kl.Map) {
+	if reflectx.IsNil(kl.Map) {
 		return
 	}
 	reflectx.MapDelete(kl.Map, reflectx.NonPointerValue(key))
@@ -204,7 +204,7 @@ func (kl *KeyedList) DeleteItem(key reflect.Value) {
 }
 
 func (kl *KeyedList) MakeToolbar(p *tree.Plan) {
-	if reflectx.AnyIsNil(kl.Map) {
+	if reflectx.IsNil(kl.Map) {
 		return
 	}
 	tree.Add(p, func(w *Button) {

--- a/core/list.go
+++ b/core/list.go
@@ -427,7 +427,7 @@ func (lb *ListBase) SetSlice(sl any) *ListBase {
 	lb.Slice = sl
 	lb.sliceUnderlying = reflectx.Underlying(reflect.ValueOf(lb.Slice))
 	lb.isArray = reflectx.NonPointerType(reflect.TypeOf(sl)).Kind() == reflect.Array
-	lb.elementValue = reflectx.SliceElementValue(sl)
+	lb.elementValue = reflectx.Underlying(reflectx.SliceElementValue(sl))
 	lb.SetSliceBase()
 	return lb
 }
@@ -485,8 +485,8 @@ func (lb *ListBase) BindSelect(val *int) *ListBase {
 
 func (lb *ListBase) UpdateMaxWidths() {
 	lb.maxWidth = 0
-	npv := reflectx.NonPointerValue(lb.elementValue)
-	isString := npv.Type().Kind() == reflect.String && npv.Type() != reflect.TypeFor[icons.Icon]()
+	ev := lb.elementValue
+	isString := ev.Type().Kind() == reflect.String && ev.Type() != reflect.TypeFor[icons.Icon]()
 	if !isString || lb.SliceSize == 0 {
 		return
 	}
@@ -505,10 +505,10 @@ func (lb *ListBase) sliceElementValue(si int) reflect.Value {
 	if si < lb.SliceSize {
 		val = reflectx.Underlying(lb.sliceUnderlying.Index(si)) // deal with pointer lists
 	} else {
-		val = reflectx.Underlying(lb.elementValue)
+		val = lb.elementValue
 	}
 	if !val.IsValid() {
-		val = reflectx.Underlying(lb.elementValue)
+		val = lb.elementValue
 	}
 	return val
 }

--- a/core/list.go
+++ b/core/list.go
@@ -407,7 +407,7 @@ func (lb *ListBase) SetSliceBase() {
 // Note: it is important to at least set an empty slice of
 // the desired type at the start to enable initial configuration.
 func (lb *ListBase) SetSlice(sl any) *ListBase {
-	if reflectx.AnyIsNil(sl) {
+	if reflectx.IsNil(sl) {
 		lb.Slice = nil
 		return lb
 	}
@@ -803,7 +803,7 @@ func (lb *ListBase) DeleteAt(i int) {
 }
 
 func (lb *ListBase) MakeToolbar(p *tree.Plan) {
-	if reflectx.AnyIsNil(lb.Slice) {
+	if reflectx.IsNil(lb.Slice) {
 		return
 	}
 	if lb.isArray || lb.IsReadOnly() {

--- a/core/list.go
+++ b/core/list.go
@@ -407,7 +407,7 @@ func (lb *ListBase) SetSliceBase() {
 // Note: it is important to at least set an empty slice of
 // the desired type at the start to enable initial configuration.
 func (lb *ListBase) SetSlice(sl any) *ListBase {
-	if reflectx.IsNil(sl) {
+	if reflectx.IsNil(reflect.ValueOf(sl)) {
 		lb.Slice = nil
 		return lb
 	}
@@ -803,7 +803,7 @@ func (lb *ListBase) DeleteAt(i int) {
 }
 
 func (lb *ListBase) MakeToolbar(p *tree.Plan) {
-	if reflectx.IsNil(lb.Slice) {
+	if reflectx.IsNil(reflect.ValueOf(lb.Slice)) {
 		return
 	}
 	if lb.isArray || lb.IsReadOnly() {

--- a/core/table.go
+++ b/core/table.go
@@ -121,7 +121,7 @@ func (tb *Table) StyleValue(w Widget, s *styles.Style, row, col int) {
 
 // SetSlice sets the source slice that we are viewing.
 func (tb *Table) SetSlice(sl any) *Table {
-	if reflectx.AnyIsNil(sl) {
+	if reflectx.IsNil(sl) {
 		tb.Slice = nil
 		return tb
 	}

--- a/core/table.go
+++ b/core/table.go
@@ -121,7 +121,7 @@ func (tb *Table) StyleValue(w Widget, s *styles.Style, row, col int) {
 
 // SetSlice sets the source slice that we are viewing.
 func (tb *Table) SetSlice(sl any) *Table {
-	if reflectx.IsNil(sl) {
+	if reflectx.IsNil(reflect.ValueOf(sl)) {
 		tb.Slice = nil
 		return tb
 	}

--- a/core/valuer.go
+++ b/core/valuer.go
@@ -85,7 +85,7 @@ func toValue(value any, tags reflect.StructTag) Value {
 		return NewText()
 	}
 	uv := reflectx.Underlying(rv)
-	if !uv.IsValid() {
+	if reflectx.IsNil(uv) {
 		return NewText()
 	}
 	typ := uv.Type()

--- a/core/windowlists.go
+++ b/core/windowlists.go
@@ -49,7 +49,7 @@ func (wl *renderWindowList) FindName(name string) *renderWindow {
 // window and true if found, nil, false otherwise.
 // data of type string works fine -- does equality comparison on string contents.
 func (wl *renderWindowList) findData(data any) (*renderWindow, bool) {
-	if reflectx.AnyIsNil(data) {
+	if reflectx.IsNil(data) {
 		return nil, false
 	}
 	typ := reflect.TypeOf(data)

--- a/core/windowlists.go
+++ b/core/windowlists.go
@@ -49,7 +49,7 @@ func (wl *renderWindowList) FindName(name string) *renderWindow {
 // window and true if found, nil, false otherwise.
 // data of type string works fine -- does equality comparison on string contents.
 func (wl *renderWindowList) findData(data any) (*renderWindow, bool) {
-	if reflectx.IsNil(data) {
+	if reflectx.IsNil(reflect.ValueOf(data)) {
 		return nil, false
 	}
 	typ := reflect.TypeOf(data)

--- a/parse/lexer/errors.go
+++ b/parse/lexer/errors.go
@@ -67,7 +67,7 @@ func (e Error) Report(basepath string, showSrc, showRule bool) string {
 		}
 	}
 	str := fnm + ":" + e.Pos.String() + ": " + e.Msg
-	if showRule && !reflectx.AnyIsNil(e.Rule) {
+	if showRule && !reflectx.IsNil(e.Rule) {
 		str += fmt.Sprintf(" (rule: %v)", e.Rule.AsTree().Name)
 	}
 	ssz := len(e.Src)

--- a/parse/lexer/errors.go
+++ b/parse/lexer/errors.go
@@ -14,6 +14,7 @@ import (
 	"fmt"
 	"io"
 	"path/filepath"
+	"reflect"
 	"sort"
 
 	"cogentcore.org/core/base/reflectx"
@@ -67,7 +68,7 @@ func (e Error) Report(basepath string, showSrc, showRule bool) string {
 		}
 	}
 	str := fnm + ":" + e.Pos.String() + ": " + e.Msg
-	if showRule && !reflectx.IsNil(e.Rule) {
+	if showRule && !reflectx.IsNil(reflect.ValueOf(e.Rule)) {
 		str += fmt.Sprintf(" (rule: %v)", e.Rule.AsTree().Name)
 	}
 	ssz := len(e.Src)

--- a/styles/style_props.go
+++ b/styles/style_props.go
@@ -22,7 +22,7 @@ func styleInhInit(val, parent any) (inh, init bool) {
 	if str, ok := val.(string); ok {
 		switch str {
 		case "inherit":
-			return !reflectx.AnyIsNil(parent), false
+			return !reflectx.IsNil(parent), false
 		case "initial":
 			return false, true
 		default:

--- a/styles/style_props.go
+++ b/styles/style_props.go
@@ -6,6 +6,7 @@ package styles
 
 import (
 	"log/slog"
+	"reflect"
 
 	"cogentcore.org/core/base/errors"
 	"cogentcore.org/core/base/num"
@@ -22,7 +23,7 @@ func styleInhInit(val, parent any) (inh, init bool) {
 	if str, ok := val.(string); ok {
 		switch str {
 		case "inherit":
-			return !reflectx.IsNil(parent), false
+			return !reflectx.IsNil(reflect.ValueOf(parent)), false
 		case "initial":
 			return false, true
 		default:

--- a/yaegicore/symbols/cogentcore_org-core-base-reflectx.go
+++ b/yaegicore/symbols/cogentcore_org-core-base-reflectx.go
@@ -11,7 +11,7 @@ import (
 func init() {
 	Symbols["cogentcore.org/core/base/reflectx/reflectx"] = map[string]reflect.Value{
 		// function, constant and variable definitions
-		"AnyIsNil":           reflect.ValueOf(reflectx.AnyIsNil),
+		"AnyIsNil":           reflect.ValueOf(reflectx.IsNil),
 		"CloneToType":        reflect.ValueOf(reflectx.CloneToType),
 		"CopyMapRobust":      reflect.ValueOf(reflectx.CopyMapRobust),
 		"CopySliceRobust":    reflect.ValueOf(reflectx.CopySliceRobust),

--- a/yaegicore/symbols/cogentcore_org-core-base-reflectx.go
+++ b/yaegicore/symbols/cogentcore_org-core-base-reflectx.go
@@ -11,11 +11,11 @@ import (
 func init() {
 	Symbols["cogentcore.org/core/base/reflectx/reflectx"] = map[string]reflect.Value{
 		// function, constant and variable definitions
-		"AnyIsNil":           reflect.ValueOf(reflectx.IsNil),
 		"CloneToType":        reflect.ValueOf(reflectx.CloneToType),
 		"CopyMapRobust":      reflect.ValueOf(reflectx.CopyMapRobust),
 		"CopySliceRobust":    reflect.ValueOf(reflectx.CopySliceRobust),
 		"FormatDefault":      reflect.ValueOf(reflectx.FormatDefault),
+		"IsNil":              reflect.ValueOf(reflectx.IsNil),
 		"KindIsBasic":        reflect.ValueOf(reflectx.KindIsBasic),
 		"KindIsNumber":       reflect.ValueOf(reflectx.KindIsNumber),
 		"LongTypeName":       reflect.ValueOf(reflectx.LongTypeName),


### PR DESCRIPTION
This PR makes `reflectx.NonPointerValue`, `Underlying`, and `UnderlyingPointer` take a best-effort approach to nil pointers and interfaces, returning the nil pointer or interface instead of returning an invalid reflect value. This prevents various crashes and increases overall robustness at the cost of causing other issues, which this PR also resolves using the renamed and improved `reflectx.IsNil` function in place of `IsValid` after getting `Underlying` values. This PR also adds a set of `reflectx` pointer tests, which should hopefully significantly reduce the chance of future reflection-related regressions and crashes.

Fixes #1320 