### PR TITLE
scene-level start focus must be in the scene doUpdate pass for menus

### DIFF
--- a/core/menu.go
+++ b/core/menu.go
@@ -85,7 +85,7 @@ func newMenuScene(menu func(m *Scene), name ...string) *Scene {
 			}
 		}
 		if !hasSelected && cwb.StateIs(states.Selected) {
-			// fmt.Println("start focus sel:", wb)
+			// fmt.Println("start focus sel:", cwb)
 			msc.Events.SetStartFocus(cwb)
 			hasSelected = true
 		}

--- a/core/render.go
+++ b/core/render.go
@@ -215,6 +215,9 @@ func (sc *Scene) doUpdate() bool {
 
 	if sc.showIter == sceneShowIters { // end of first pass
 		sc.showIter++ // just go 1 past the iters cutoff
+		if !sc.hasFlag(sceneContentSizing) {
+			sc.Events.activateStartFocus()
+		}
 	}
 	return true
 }

--- a/core/stages.go
+++ b/core/stages.go
@@ -262,9 +262,6 @@ func (sm *stages) runDeferred() {
 		if sc.showIter == sceneShowIters+1 {
 			sc.showIter++
 			if !sc.hasFlag(sceneHasShown) {
-				if !sc.hasFlag(sceneContentSizing) {
-					sc.Events.activateStartFocus()
-				}
 				sc.setFlag(true, sceneHasShown)
 				sc.Shown()
 			}


### PR DESCRIPTION
#1337 broke startfocus on menus -- this fixes it.

menus and other popups don't get to the run deferred pathway, so they weren't getting this called.
