### PR TITLE
events does a focusClear just before sending Click event

### DIFF
--- a/core/dialog.go
+++ b/core/dialog.go
@@ -126,9 +126,6 @@ func ErrorDialog(ctx Widget, err error, title ...string) {
 // beyond that. Also see [Body.AddOKOnly].
 func (bd *Body) AddOK(parent Widget) *Button {
 	bt := NewButton(parent).SetText("OK")
-	bt.OnFirst(events.Click, func(e events.Event) { // first de-focus any active editors
-		bt.focusClear()
-	})
 	bt.OnFinal(events.Click, func(e events.Event) { // then close
 		e.SetHandled() // otherwise propagates to dead elements
 		bd.Close()

--- a/core/events.go
+++ b/core/events.go
@@ -474,6 +474,10 @@ func (em *Events) handlePosEvent(e events.Event) {
 				if !sentMulti {
 					em.lastDoubleClickWidget = nil
 					em.lastClickWidget = up
+					if em.focus != up {
+						em.focusClear() // always any other focus before the click is processed
+						// this causes textfields etc to apply their changes.
+					}
 					up.AsWidget().Send(events.Click, e)
 				}
 			case events.Right: // note: automatically gets Control+Left

--- a/core/events.go
+++ b/core/events.go
@@ -474,11 +474,6 @@ func (em *Events) handlePosEvent(e events.Event) {
 				if !sentMulti {
 					em.lastDoubleClickWidget = nil
 					em.lastClickWidget = up
-					if em.focus != up {
-						// always clear any other focus before the click is processed.
-						// this causes textfields etc to apply their changes.
-						em.focusClear()
-					}
 					up.AsWidget().Send(events.Click, e)
 				}
 			case events.Right: // note: automatically gets Control+Left

--- a/core/events.go
+++ b/core/events.go
@@ -475,8 +475,9 @@ func (em *Events) handlePosEvent(e events.Event) {
 					em.lastDoubleClickWidget = nil
 					em.lastClickWidget = up
 					if em.focus != up {
-						em.focusClear() // always any other focus before the click is processed
+						// always clear any other focus before the click is processed.
 						// this causes textfields etc to apply their changes.
+						em.focusClear()
 					}
 					up.AsWidget().Send(events.Click, e)
 				}

--- a/core/widgetevents.go
+++ b/core/widgetevents.go
@@ -170,6 +170,14 @@ func (wb *WidgetBase) Send(typ events.Types, original ...events.Event) {
 	if wb.This == nil {
 		return
 	}
+	if typ == events.Click {
+		em := wb.Events()
+		if em != nil && em.focus != wb.This.(Widget) {
+			// always clear any other focus before the click is processed.
+			// this causes textfields etc to apply their changes.
+			em.focusClear()
+		}
+	}
 	var e events.Event
 	if len(original) > 0 && original[0] != nil {
 		e = original[0].NewFromClone(typ)


### PR DESCRIPTION
if focus widget is not the clicked widget. This provides a robust, general solution to applying changes in textfields etc prior to clicking on buttons etc. Fixes #1158
