### PR TITLE
Use debug.ReadBuildInfo for version displaying in core tool (cli) and as a backup in apps

### DIFF
--- a/cli/usage.go
+++ b/cli/usage.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"runtime/debug"
 	"slices"
 	"strconv"
 	"strings"
@@ -47,6 +48,19 @@ func usage[T any](opts *Options, cfg T, cmd string, cmds ...*Cmd[T]) string {
 			fmt.Println(logx.CmdColor(cmdName()+" help") + logx.ErrorColor(fmt.Sprintf(" failed: command %q not found", cmd)))
 			os.Exit(1)
 		}
+	}
+
+	if bi, ok := debug.ReadBuildInfo(); ok {
+		revision, time := "dev", "unknown"
+		for _, set := range bi.Settings {
+			if set.Key == "vcs.revision" {
+				revision = set.Value
+			}
+			if set.Key == "vcs.time" {
+				time = set.Value
+			}
+		}
+		b.WriteString(logx.TitleColor("Version: ") + fmt.Sprintf("%s (%s)\n\n", revision, time))
 	}
 
 	fs := &fields{}

--- a/cmd/core/config/config.go
+++ b/cmd/core/config/config.go
@@ -247,6 +247,12 @@ func LinkerFlags(c *Config) string {
 		res += "-X 'cogentcore.org/core/core.AppIcon=" + strings.ReplaceAll(string(b), "'", `\'`) + "' "
 	}
 
+	// TODO: maybe replace this linker flag version injection logic with
+	// [debug.ReadBuildInfo] at some point; we currently support it as a
+	// backup in system/app.go, but it is less reliable and formats worse,
+	// so we won't use it as a full replacement yet (see
+	// https://github.com/cogentcore/core/issues/1370).
+
 	av, err := exec.Silent().Output("git", "describe", "--tags")
 	if err == nil {
 		res += "-X cogentcore.org/core/system.AppVersion=" + av + " "

--- a/system/app.go
+++ b/system/app.go
@@ -12,7 +12,12 @@
 // functionality needed for full GUI support.
 package system
 
-import "cogentcore.org/core/styles"
+import (
+	"fmt"
+	"runtime/debug"
+
+	"cogentcore.org/core/styles"
+)
 
 //go:generate core generate
 
@@ -21,11 +26,13 @@ var (
 	TheApp App
 
 	// AppVersion is the version of the current app.
-	// It is set by a linker flag in the core command line tool.
+	// It is set by a linker flag in the core command line tool,
+	// with a backup based on [debug.ReadBuildInfo].
 	AppVersion = "dev"
 
 	// CoreVersion is the version of Cogent Core that the current app is using.
-	// It is set by a linker flag in the core command line tool.
+	// It is set by a linker flag in the core command line tool,
+	// with a backup based on [debug.ReadBuildInfo].
 	CoreVersion = "dev"
 
 	// ReservedWebShortcuts is a list of shortcuts that are reserved on the web
@@ -234,4 +241,38 @@ const (
 // considered mobile platforms because they only support one window.
 func (p Platforms) IsMobile() bool {
 	return p == IOS || p == Android || p == Web || p == Offscreen
+}
+
+func init() {
+	// We only need this backup [debug.ReadBuildInfo] logic if the versions
+	// weren't already set by the linker flags in the core tool.
+	if AppVersion != "dev" || CoreVersion != "dev" {
+		return
+	}
+	bi, ok := debug.ReadBuildInfo()
+	if !ok {
+		return
+	}
+
+	revision, time := "dev", "unknown"
+	for _, set := range bi.Settings {
+		if set.Key == "vcs.revision" {
+			revision = set.Value
+		}
+		if set.Key == "vcs.time" {
+			time = set.Value
+		}
+	}
+	AppVersion = fmt.Sprintf("%s (%s)", revision, time)
+
+	if bi.Main.Path == "cogentcore.org/core" {
+		CoreVersion = AppVersion
+	} else {
+		for _, dep := range bi.Deps {
+			if dep.Path == "cogentcore.org/core" {
+				CoreVersion = dep.Version
+				break
+			}
+		}
+	}
 }

--- a/system/driver/web/cursor.go
+++ b/system/driver/web/cursor.go
@@ -12,11 +12,12 @@ import (
 
 	"cogentcore.org/core/cursors"
 	"cogentcore.org/core/enums"
+	"cogentcore.org/core/styles/units"
 	"cogentcore.org/core/system"
 )
 
 // TheCursor is the single [system.Cursor] for the web platform
-var TheCursor = &Cursor{CursorBase: system.CursorBase{Vis: true, Size: 32}}
+var TheCursor = &Cursor{CursorBase: system.CursorBase{Vis: true, Size: units.Dp(32)}}
 
 // Cursor is the [system.Cursor] implementation for the web platform
 type Cursor struct {


### PR DESCRIPTION
Use `debug.ReadBuildInfo` for displaying the version in the `cli` usage string, such as for the core tool. Also use `debug.ReadBuildInfo` as a backup for `system.AppVersion` and `system.CoreVersion` if those versions weren't already set by the core tool.

Also fixes a cursor build error on web caused by #1372.

For #1370. This is not a full fix as discussed there.