### PR TITLE
fileinfo: only get mimeinfo and generated from regular files

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -31,6 +31,9 @@ jobs:
     - name: Test
       run: go test -v $(go list ./... | grep -v gpu | grep -v xyz | grep -v system) -coverprofile cover.out -timeout 30s
 
+    - name: Build Docs test
+      run: core build web -dir docs -o static
+
     - name: Update coverage report
       uses: ncruces/go-coverage-report@v0
       with:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -31,7 +31,7 @@ jobs:
     - name: Test
       run: go test -v $(go list ./... | grep -v gpu | grep -v xyz | grep -v system) -coverprofile cover.out -timeout 30s
 
-    - name: Build Docs test
+    - name: Build Docs (to verify it works on PRs)
       run: core build web -dir docs -o static
 
     - name: Update coverage report

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -27,12 +27,12 @@ jobs:
     - name: Build
       run: go build -v ./...
 
+    - name: Build Docs (to verify it works on PRs)
+      run: core build web -dir docs -o static
+
     # we can't test gpu, xyz, and system on the CI since there is no Vulkan support
     - name: Test
       run: go test -v $(go list ./... | grep -v gpu | grep -v xyz | grep -v system) -coverprofile cover.out -timeout 30s
-
-    - name: Build Docs (to verify it works on PRs)
-      run: core build web -dir docs -o static
 
     - name: Update coverage report
       uses: ncruces/go-coverage-report@v0

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -36,7 +36,7 @@ jobs:
 
     - name: Build Docs
       run: core build web -dir docs -o static -vanity-url cogentcore.org/core -github-vanity-repository cogentcore/core
-	
+
     - name: Update coverage report
       uses: ncruces/go-coverage-report@v0
       with:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -28,9 +28,15 @@ jobs:
       run: go build -v ./...
 
     # we can't test gpu, xyz, and system on the CI since there is no Vulkan support
-    - name: Test
-      run: go test -v $(go list ./... | grep -v gpu | grep -v xyz | grep -v system) -coverprofile cover.out -timeout 30s
+#    - name: Test
+#      run: go test -v $(go list ./... | grep -v gpu | grep -v xyz | grep -v system) -coverprofile cover.out -timeout 30s
 
+    - name: Install Core
+      run: go install ./cmd/core
+
+    - name: Build Docs
+      run: core build web -dir docs -o static -vanity-url cogentcore.org/core -github-vanity-repository cogentcore/core
+	
     - name: Update coverage report
       uses: ncruces/go-coverage-report@v0
       with:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -28,14 +28,8 @@ jobs:
       run: go build -v ./...
 
     # we can't test gpu, xyz, and system on the CI since there is no Vulkan support
-#    - name: Test
-#      run: go test -v $(go list ./... | grep -v gpu | grep -v xyz | grep -v system) -coverprofile cover.out -timeout 30s
-
-    - name: Install Core
-      run: go install ./cmd/core
-
-    - name: Build Docs
-      run: core build web -dir docs -o static -vanity-url cogentcore.org/core -github-vanity-repository cogentcore/core
+    - name: Test
+      run: go test -v $(go list ./... | grep -v gpu | grep -v xyz | grep -v system) -coverprofile cover.out -timeout 30s
 
     - name: Update coverage report
       uses: ncruces/go-coverage-report@v0

--- a/base/fileinfo/fileinfo.go
+++ b/base/fileinfo/fileinfo.go
@@ -103,6 +103,10 @@ func NewFileInfoType(ftyp Known) *FileInfo {
 // but file info will be updated based on the filename even if
 // the file does not exist.
 func (fi *FileInfo) InitFile(fname string) error {
+	fi.Cat = UnknownCategory
+	fi.Known = Unknown
+	fi.Generated = false
+	fi.Kind = ""
 	var errs []error
 	path, err := filepath.Abs(fname)
 	if err == nil {
@@ -111,7 +115,6 @@ func (fi *FileInfo) InitFile(fname string) error {
 		fi.Path = fname
 	}
 	_, fi.Name = filepath.Split(path)
-	fi.SetMimeInfo()
 	info, err := os.Stat(fi.Path)
 	if err != nil {
 		errs = append(errs, err)
@@ -126,10 +129,13 @@ func (fi *FileInfo) InitFile(fname string) error {
 // but file info will be updated based on the filename even if
 // the file does not exist.
 func (fi *FileInfo) InitFileFS(fsys fs.FS, fname string) error {
+	fi.Cat = UnknownCategory
+	fi.Known = Unknown
+	fi.Generated = false
+	fi.Kind = ""
 	var errs []error
 	fi.Path = fname
 	_, fi.Name = path.Split(fname)
-	fi.SetMimeInfo()
 	info, err := fs.Stat(fsys, fi.Path)
 	if err != nil {
 		errs = append(errs, err)
@@ -145,10 +151,7 @@ func (fi *FileInfo) SetMimeInfo() error {
 	if fi.Path == "" || fi.Path == "." || fi.IsDir() {
 		return nil
 	}
-	fi.Cat = UnknownCategory
-	fi.Known = Unknown
 	fi.Generated = IsGeneratedFile(fi.Path)
-	fi.Kind = ""
 	mtyp, _, err := MimeFromFile(fi.Path)
 	if err != nil {
 		return err
@@ -177,6 +180,9 @@ func (fi *FileInfo) SetFileInfo(info fs.FileInfo) {
 		fi.Cat = Folder
 		fi.Known = AnyFolder
 	} else {
+		if fi.Mode.IsRegular() {
+			fi.SetMimeInfo()
+		}
 		if fi.Cat == UnknownCategory {
 			if fi.IsExec() {
 				fi.Cat = Exe


### PR DESCRIPTION
This should fix the CD of pages / docs, and generally be more robust.

*Edit from @kkoreilly: this supersedes and thus closes #1395, which was useful for debugging but did not contain a fix*
