### PR TITLE
refactor: replace `fmt.Errorf` by (more efficient) `errors.New` 

### DIFF
--- a/base/fileinfo/fileinfo.go
+++ b/base/fileinfo/fileinfo.go
@@ -318,7 +318,7 @@ func (fi *FileInfo) Filenames(names *[]string) (err error) {
 // Does not actually do the renaming -- see Rename method.
 func (fi *FileInfo) RenamePath(path string) (newpath string, err error) {
 	if path == "" {
-		err = fmt.Errorf("core.Rename: new name is empty")
+		err = errors.New("core.Rename: new name is empty")
 		log.Println(err)
 		return path, err
 	}

--- a/base/iox/imagex/imagex.go
+++ b/base/iox/imagex/imagex.go
@@ -8,6 +8,7 @@ package imagex
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"image"
 	"image/draw"
@@ -43,7 +44,7 @@ const (
 // which can start with a . or not
 func ExtToFormat(ext string) (Formats, error) {
 	if len(ext) == 0 {
-		return None, fmt.Errorf("ExtToFormat: ext is empty")
+		return None, errors.New("ExtToFormat: ext is empty")
 	}
 	if ext[0] == '.' {
 		ext = ext[1:]

--- a/base/iox/tomlx/tomlx.go
+++ b/base/iox/tomlx/tomlx.go
@@ -5,7 +5,7 @@
 package tomlx
 
 import (
-	"fmt"
+	"errors"
 	"io"
 	"io/fs"
 
@@ -77,7 +77,7 @@ func WriteBytes(v any) ([]byte, error) {
 func OpenFromPaths(v any, file string, paths ...string) error {
 	filenames := fsx.FindFilesOnPaths(paths, file)
 	if len(filenames) == 0 {
-		return fmt.Errorf("OpenFromPaths: no files found")
+		return errors.New("OpenFromPaths: no files found")
 	}
 	return Open(v, filenames[0])
 }

--- a/base/reflectx/values.go
+++ b/base/reflectx/values.go
@@ -17,6 +17,7 @@ import (
 
 	"cogentcore.org/core/base/bools"
 	"cogentcore.org/core/base/elide"
+	"cogentcore.org/core/base/errors"
 	"cogentcore.org/core/colors"
 	"cogentcore.org/core/enums"
 )
@@ -70,7 +71,7 @@ func ToBool(v any) (bool, error) {
 		return vt, nil
 	case *bool:
 		if vt == nil {
-			return false, fmt.Errorf("got nil *bool")
+			return false, errors.New("got nil *bool")
 		}
 		return *vt, nil
 	}
@@ -84,42 +85,42 @@ func ToBool(v any) (bool, error) {
 		return vt != 0, nil
 	case *int:
 		if vt == nil {
-			return false, fmt.Errorf("got nil *int")
+			return false, errors.New("got nil *int")
 		}
 		return *vt != 0, nil
 	case int32:
 		return vt != 0, nil
 	case *int32:
 		if vt == nil {
-			return false, fmt.Errorf("got nil *int32")
+			return false, errors.New("got nil *int32")
 		}
 		return *vt != 0, nil
 	case int64:
 		return vt != 0, nil
 	case *int64:
 		if vt == nil {
-			return false, fmt.Errorf("got nil *int64")
+			return false, errors.New("got nil *int64")
 		}
 		return *vt != 0, nil
 	case uint8:
 		return vt != 0, nil
 	case *uint8:
 		if vt == nil {
-			return false, fmt.Errorf("got nil *uint8")
+			return false, errors.New("got nil *uint8")
 		}
 		return *vt != 0, nil
 	case float64:
 		return vt != 0, nil
 	case *float64:
 		if vt == nil {
-			return false, fmt.Errorf("got nil *float64")
+			return false, errors.New("got nil *float64")
 		}
 		return *vt != 0, nil
 	case float32:
 		return vt != 0, nil
 	case *float32:
 		if vt == nil {
-			return false, fmt.Errorf("got nil *float32")
+			return false, errors.New("got nil *float32")
 		}
 		return *vt != 0, nil
 	case string:
@@ -130,7 +131,7 @@ func ToBool(v any) (bool, error) {
 		return r, nil
 	case *string:
 		if vt == nil {
-			return false, fmt.Errorf("got nil *string")
+			return false, errors.New("got nil *string")
 		}
 		r, err := strconv.ParseBool(*vt)
 		if err != nil {
@@ -141,49 +142,49 @@ func ToBool(v any) (bool, error) {
 		return vt != 0, nil
 	case *int8:
 		if vt == nil {
-			return false, fmt.Errorf("got nil *int8")
+			return false, errors.New("got nil *int8")
 		}
 		return *vt != 0, nil
 	case int16:
 		return vt != 0, nil
 	case *int16:
 		if vt == nil {
-			return false, fmt.Errorf("got nil *int16")
+			return false, errors.New("got nil *int16")
 		}
 		return *vt != 0, nil
 	case uint:
 		return vt != 0, nil
 	case *uint:
 		if vt == nil {
-			return false, fmt.Errorf("got nil *uint")
+			return false, errors.New("got nil *uint")
 		}
 		return *vt != 0, nil
 	case uint16:
 		return vt != 0, nil
 	case *uint16:
 		if vt == nil {
-			return false, fmt.Errorf("got nil *uint16")
+			return false, errors.New("got nil *uint16")
 		}
 		return *vt != 0, nil
 	case uint32:
 		return vt != 0, nil
 	case *uint32:
 		if vt == nil {
-			return false, fmt.Errorf("got nil *uint32")
+			return false, errors.New("got nil *uint32")
 		}
 		return *vt != 0, nil
 	case uint64:
 		return vt != 0, nil
 	case *uint64:
 		if vt == nil {
-			return false, fmt.Errorf("got nil *uint64")
+			return false, errors.New("got nil *uint64")
 		}
 		return *vt != 0, nil
 	case uintptr:
 		return vt != 0, nil
 	case *uintptr:
 		if vt == nil {
-			return false, fmt.Errorf("got nil *uintptr")
+			return false, errors.New("got nil *uintptr")
 		}
 		return *vt != 0, nil
 	}
@@ -226,42 +227,42 @@ func ToInt(v any) (int64, error) {
 		return int64(vt), nil
 	case *int:
 		if vt == nil {
-			return 0, fmt.Errorf("got nil *int")
+			return 0, errors.New("got nil *int")
 		}
 		return int64(*vt), nil
 	case int32:
 		return int64(vt), nil
 	case *int32:
 		if vt == nil {
-			return 0, fmt.Errorf("got nil *int32")
+			return 0, errors.New("got nil *int32")
 		}
 		return int64(*vt), nil
 	case int64:
 		return vt, nil
 	case *int64:
 		if vt == nil {
-			return 0, fmt.Errorf("got nil *int64")
+			return 0, errors.New("got nil *int64")
 		}
 		return *vt, nil
 	case uint8:
 		return int64(vt), nil
 	case *uint8:
 		if vt == nil {
-			return 0, fmt.Errorf("got nil *uint8")
+			return 0, errors.New("got nil *uint8")
 		}
 		return int64(*vt), nil
 	case float64:
 		return int64(vt), nil
 	case *float64:
 		if vt == nil {
-			return 0, fmt.Errorf("got nil *float64")
+			return 0, errors.New("got nil *float64")
 		}
 		return int64(*vt), nil
 	case float32:
 		return int64(vt), nil
 	case *float32:
 		if vt == nil {
-			return 0, fmt.Errorf("got nil *float32")
+			return 0, errors.New("got nil *float32")
 		}
 		return int64(*vt), nil
 	case bool:
@@ -271,7 +272,7 @@ func ToInt(v any) (int64, error) {
 		return 0, nil
 	case *bool:
 		if vt == nil {
-			return 0, fmt.Errorf("got nil *bool")
+			return 0, errors.New("got nil *bool")
 		}
 		if *vt {
 			return 1, nil
@@ -285,7 +286,7 @@ func ToInt(v any) (int64, error) {
 		return r, nil
 	case *string:
 		if vt == nil {
-			return 0, fmt.Errorf("got nil *string")
+			return 0, errors.New("got nil *string")
 		}
 		r, err := strconv.ParseInt(*vt, 0, 64)
 		if err != nil {
@@ -298,49 +299,49 @@ func ToInt(v any) (int64, error) {
 		return int64(vt), nil
 	case *int8:
 		if vt == nil {
-			return 0, fmt.Errorf("got nil *int8")
+			return 0, errors.New("got nil *int8")
 		}
 		return int64(*vt), nil
 	case int16:
 		return int64(vt), nil
 	case *int16:
 		if vt == nil {
-			return 0, fmt.Errorf("got nil *int16")
+			return 0, errors.New("got nil *int16")
 		}
 		return int64(*vt), nil
 	case uint:
 		return int64(vt), nil
 	case *uint:
 		if vt == nil {
-			return 0, fmt.Errorf("got nil *uint")
+			return 0, errors.New("got nil *uint")
 		}
 		return int64(*vt), nil
 	case uint16:
 		return int64(vt), nil
 	case *uint16:
 		if vt == nil {
-			return 0, fmt.Errorf("got nil *uint16")
+			return 0, errors.New("got nil *uint16")
 		}
 		return int64(*vt), nil
 	case uint32:
 		return int64(vt), nil
 	case *uint32:
 		if vt == nil {
-			return 0, fmt.Errorf("got nil *uint32")
+			return 0, errors.New("got nil *uint32")
 		}
 		return int64(*vt), nil
 	case uint64:
 		return int64(vt), nil
 	case *uint64:
 		if vt == nil {
-			return 0, fmt.Errorf("got nil *uint64")
+			return 0, errors.New("got nil *uint64")
 		}
 		return int64(*vt), nil
 	case uintptr:
 		return int64(vt), nil
 	case *uintptr:
 		if vt == nil {
-			return 0, fmt.Errorf("got nil *uintptr")
+			return 0, errors.New("got nil *uintptr")
 		}
 		return int64(*vt), nil
 	}
@@ -385,42 +386,42 @@ func ToFloat(v any) (float64, error) {
 		return vt, nil
 	case *float64:
 		if vt == nil {
-			return 0, fmt.Errorf("got nil *float64")
+			return 0, errors.New("got nil *float64")
 		}
 		return *vt, nil
 	case float32:
 		return float64(vt), nil
 	case *float32:
 		if vt == nil {
-			return 0, fmt.Errorf("got nil *float32")
+			return 0, errors.New("got nil *float32")
 		}
 		return float64(*vt), nil
 	case int:
 		return float64(vt), nil
 	case *int:
 		if vt == nil {
-			return 0, fmt.Errorf("got nil *int")
+			return 0, errors.New("got nil *int")
 		}
 		return float64(*vt), nil
 	case int32:
 		return float64(vt), nil
 	case *int32:
 		if vt == nil {
-			return 0, fmt.Errorf("got nil *int32")
+			return 0, errors.New("got nil *int32")
 		}
 		return float64(*vt), nil
 	case int64:
 		return float64(vt), nil
 	case *int64:
 		if vt == nil {
-			return 0, fmt.Errorf("got nil *int64")
+			return 0, errors.New("got nil *int64")
 		}
 		return float64(*vt), nil
 	case uint8:
 		return float64(vt), nil
 	case *uint8:
 		if vt == nil {
-			return 0, fmt.Errorf("got nil *uint8")
+			return 0, errors.New("got nil *uint8")
 		}
 		return float64(*vt), nil
 	case bool:
@@ -430,7 +431,7 @@ func ToFloat(v any) (float64, error) {
 		return 0, nil
 	case *bool:
 		if vt == nil {
-			return 0, fmt.Errorf("got nil *bool")
+			return 0, errors.New("got nil *bool")
 		}
 		if *vt {
 			return 1, nil
@@ -444,7 +445,7 @@ func ToFloat(v any) (float64, error) {
 		return r, nil
 	case *string:
 		if vt == nil {
-			return 0, fmt.Errorf("got nil *string")
+			return 0, errors.New("got nil *string")
 		}
 		r, err := strconv.ParseFloat(*vt, 64)
 		if err != nil {
@@ -455,49 +456,49 @@ func ToFloat(v any) (float64, error) {
 		return float64(vt), nil
 	case *int8:
 		if vt == nil {
-			return 0, fmt.Errorf("got nil *int8")
+			return 0, errors.New("got nil *int8")
 		}
 		return float64(*vt), nil
 	case int16:
 		return float64(vt), nil
 	case *int16:
 		if vt == nil {
-			return 0, fmt.Errorf("got nil *int16")
+			return 0, errors.New("got nil *int16")
 		}
 		return float64(*vt), nil
 	case uint:
 		return float64(vt), nil
 	case *uint:
 		if vt == nil {
-			return 0, fmt.Errorf("got nil *uint")
+			return 0, errors.New("got nil *uint")
 		}
 		return float64(*vt), nil
 	case uint16:
 		return float64(vt), nil
 	case *uint16:
 		if vt == nil {
-			return 0, fmt.Errorf("got nil *uint16")
+			return 0, errors.New("got nil *uint16")
 		}
 		return float64(*vt), nil
 	case uint32:
 		return float64(vt), nil
 	case *uint32:
 		if vt == nil {
-			return 0, fmt.Errorf("got nil *uint32")
+			return 0, errors.New("got nil *uint32")
 		}
 		return float64(*vt), nil
 	case uint64:
 		return float64(vt), nil
 	case *uint64:
 		if vt == nil {
-			return 0, fmt.Errorf("got nil *uint64")
+			return 0, errors.New("got nil *uint64")
 		}
 		return float64(*vt), nil
 	case uintptr:
 		return float64(vt), nil
 	case *uintptr:
 		if vt == nil {
-			return 0, fmt.Errorf("got nil *uintptr")
+			return 0, errors.New("got nil *uintptr")
 		}
 		return float64(*vt), nil
 	}
@@ -542,42 +543,42 @@ func ToFloat32(v any) (float32, error) {
 		return vt, nil
 	case *float32:
 		if vt == nil {
-			return 0, fmt.Errorf("got nil *float32")
+			return 0, errors.New("got nil *float32")
 		}
 		return *vt, nil
 	case float64:
 		return float32(vt), nil
 	case *float64:
 		if vt == nil {
-			return 0, fmt.Errorf("got nil *float64")
+			return 0, errors.New("got nil *float64")
 		}
 		return float32(*vt), nil
 	case int:
 		return float32(vt), nil
 	case *int:
 		if vt == nil {
-			return 0, fmt.Errorf("got nil *int")
+			return 0, errors.New("got nil *int")
 		}
 		return float32(*vt), nil
 	case int32:
 		return float32(vt), nil
 	case *int32:
 		if vt == nil {
-			return 0, fmt.Errorf("got nil *int32")
+			return 0, errors.New("got nil *int32")
 		}
 		return float32(*vt), nil
 	case int64:
 		return float32(vt), nil
 	case *int64:
 		if vt == nil {
-			return 0, fmt.Errorf("got nil *int64")
+			return 0, errors.New("got nil *int64")
 		}
 		return float32(*vt), nil
 	case uint8:
 		return float32(vt), nil
 	case *uint8:
 		if vt == nil {
-			return 0, fmt.Errorf("got nil *uint8")
+			return 0, errors.New("got nil *uint8")
 		}
 		return float32(*vt), nil
 	case bool:
@@ -587,7 +588,7 @@ func ToFloat32(v any) (float32, error) {
 		return 0, nil
 	case *bool:
 		if vt == nil {
-			return 0, fmt.Errorf("got nil *bool")
+			return 0, errors.New("got nil *bool")
 		}
 		if *vt {
 			return 1, nil
@@ -601,7 +602,7 @@ func ToFloat32(v any) (float32, error) {
 		return float32(r), nil
 	case *string:
 		if vt == nil {
-			return 0, fmt.Errorf("got nil *string")
+			return 0, errors.New("got nil *string")
 		}
 		r, err := strconv.ParseFloat(*vt, 32)
 		if err != nil {
@@ -612,49 +613,49 @@ func ToFloat32(v any) (float32, error) {
 		return float32(vt), nil
 	case *int8:
 		if vt == nil {
-			return 0, fmt.Errorf("got nil *int8")
+			return 0, errors.New("got nil *int8")
 		}
 		return float32(*vt), nil
 	case int16:
 		return float32(vt), nil
 	case *int16:
 		if vt == nil {
-			return 0, fmt.Errorf("got nil *int8")
+			return 0, errors.New("got nil *int8")
 		}
 		return float32(*vt), nil
 	case uint:
 		return float32(vt), nil
 	case *uint:
 		if vt == nil {
-			return 0, fmt.Errorf("got nil *uint")
+			return 0, errors.New("got nil *uint")
 		}
 		return float32(*vt), nil
 	case uint16:
 		return float32(vt), nil
 	case *uint16:
 		if vt == nil {
-			return 0, fmt.Errorf("got nil *uint16")
+			return 0, errors.New("got nil *uint16")
 		}
 		return float32(*vt), nil
 	case uint32:
 		return float32(vt), nil
 	case *uint32:
 		if vt == nil {
-			return 0, fmt.Errorf("got nil *uint32")
+			return 0, errors.New("got nil *uint32")
 		}
 		return float32(*vt), nil
 	case uint64:
 		return float32(vt), nil
 	case *uint64:
 		if vt == nil {
-			return 0, fmt.Errorf("got nil *uint64")
+			return 0, errors.New("got nil *uint64")
 		}
 		return float32(*vt), nil
 	case uintptr:
 		return float32(vt), nil
 	case *uintptr:
 		if vt == nil {
-			return 0, fmt.Errorf("got nil *uintptr")
+			return 0, errors.New("got nil *uintptr")
 		}
 		return float32(*vt), nil
 	}
@@ -960,7 +961,7 @@ func SetRobust(to, from any) error {
 			pto = rto
 		} else {
 			// Otherwise, we cannot recover any meaningful value.
-			return fmt.Errorf("got nil destination value")
+			return errors.New("got nil destination value")
 		}
 	}
 	pito := pto.Interface()

--- a/base/sshclient/client.go
+++ b/base/sshclient/client.go
@@ -6,6 +6,7 @@ package sshclient
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"log"
 	"log/slog"
@@ -77,7 +78,7 @@ func (cl *Client) CloseSessions() {
 func (cl *Client) Connect(host string) error {
 	if host == "" {
 		if cl.Host == "" {
-			return fmt.Errorf("ssh: Connect host is empty and no default host set in Config")
+			return errors.New("ssh: Connect host is empty and no default host set in Config")
 		}
 		host = cl.Host
 	}
@@ -137,7 +138,7 @@ func (cl *Client) Connect(host string) error {
 // config.  Only works if Client already connected.
 func (cl *Client) NewSession(interact bool) (*ssh.Session, error) {
 	if cl.Client == nil {
-		return nil, fmt.Errorf("ssh: no client, must Connect first")
+		return nil, errors.New("ssh: no client, must Connect first")
 	}
 	ses, err := cl.Client.NewSession()
 	if err != nil {

--- a/base/vcs/vcs.go
+++ b/base/vcs/vcs.go
@@ -9,7 +9,7 @@ package vcs
 //go:generate core generate
 
 import (
-	"fmt"
+	"errors"
 	"path/filepath"
 
 	"cogentcore.org/core/base/fsx"
@@ -108,9 +108,9 @@ func NewRepo(remote, local string) (Repo, error) {
 			r.SvnRepo = *(repo.(*vcs.SvnRepo))
 			return r, err
 		case vcs.Hg:
-			err = fmt.Errorf("hg version control not yet supported")
+			err = errors.New("hg version control not yet supported")
 		case vcs.Bzr:
-			err = fmt.Errorf("bzr version control not yet supported")
+			err = errors.New("bzr version control not yet supported")
 		}
 	}
 	return nil, err

--- a/cmd/core/cmd/install.go
+++ b/cmd/core/cmd/install.go
@@ -5,6 +5,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"path/filepath"
 	"runtime"
@@ -46,7 +47,7 @@ func Install(c *config.Config) error { //types:add
 				return fmt.Errorf("install: %w", err)
 			}
 		case "web":
-			return fmt.Errorf("can not install on platform web; use build or run instead")
+			return errors.New("can not install on platform web; use build or run instead")
 		case "darwin":
 			c.Pack.DMG = false
 			err := Pack(c)

--- a/cmd/core/cmd/log.go
+++ b/cmd/core/cmd/log.go
@@ -5,6 +5,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 
 	"cogentcore.org/core/base/exec"
@@ -16,7 +17,7 @@ import (
 // run for other platforms.
 func Log(c *config.Config) error { //types:add
 	if c.Log.Target != "android" {
-		return fmt.Errorf("only android is supported for log; use the -debug flag on run for other platforms")
+		return errors.New("only android is supported for log; use the -debug flag on run for other platforms")
 	}
 	if !c.Log.Keep {
 		err := exec.Run("adb", "logcat", "-c")

--- a/cmd/core/cmd/setup.go
+++ b/cmd/core/cmd/setup.go
@@ -5,6 +5,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"path/filepath"
 	"runtime"
@@ -60,7 +61,7 @@ func Setup(c *config.Config) error { //types:add
 		if _, err := exec.LookPath("nix-shell"); err == nil {
 			return vc.Run("nix-shell", "-p", "libGL", "pkg-config", "xorg.libX11.dev", "xorg.libXcursor", "xorg.libXi", "xorg.libXinerama", "xorg.libXrandr", "xorg.libXxf86vm")
 		}
-		return fmt.Errorf("unknown Linux distro; please file a bug report at https://github.com/cogentcore/core/issues")
+		return errors.New("unknown Linux distro; please file a bug report at https://github.com/cogentcore/core/issues")
 	case "windows":
 		if _, err := exec.LookPath("gcc"); err != nil {
 			err := vc.Run("curl", "-OL", "https://github.com/skeeto/w64devkit/releases/download/v2.0.0/w64devkit-x64-2.0.0.exe")

--- a/cmd/core/mobile/binres/binres.go
+++ b/cmd/core/mobile/binres/binres.go
@@ -49,6 +49,7 @@ import (
 	"encoding"
 	"encoding/binary"
 	"encoding/xml"
+	"errors"
 	"fmt"
 	"io"
 	"sort"
@@ -240,7 +241,7 @@ func UnmarshalXML(r io.Reader, withIcon bool, minSdkVersion, targetSdkVersion in
 			default:
 				q = append(q, ltoken{tkn, line})
 			case "uses-sdk":
-				return nil, fmt.Errorf("manual declaration of uses-sdk in AndroidManifest.xml not supported")
+				return nil, errors.New("manual declaration of uses-sdk in AndroidManifest.xml not supported")
 			case "manifest":
 				// synthesize additional attributes and nodes for use during encode.
 				tkn.Attr = append(tkn.Attr, xml.Attr{
@@ -292,7 +293,7 @@ func UnmarshalXML(r io.Reader, withIcon bool, minSdkVersion, targetSdkVersion in
 				if !skipSynthesize {
 					for _, attr := range tkn.Attr {
 						if attr.Name.Space == androidSchema && attr.Name.Local == "icon" {
-							return nil, fmt.Errorf("manual declaration of android:icon in AndroidManifest.xml not supported")
+							return nil, errors.New("manual declaration of android:icon in AndroidManifest.xml not supported")
 						}
 					}
 					if withIcon {
@@ -357,7 +358,7 @@ func UnmarshalXML(r io.Reader, withIcon bool, minSdkVersion, targetSdkVersion in
 
 				if attr.Name.Space == "xmlns" && attr.Name.Local == "android" {
 					if bx.Namespace != nil {
-						return nil, fmt.Errorf("multiple declarations of xmlns:android encountered")
+						return nil, errors.New("multiple declarations of xmlns:android encountered")
 					}
 					bx.Namespace = &Namespace{
 						NodeHeader: NodeHeader{
@@ -515,7 +516,7 @@ func UnmarshalXML(r io.Reader, withIcon bool, minSdkVersion, targetSdkVersion in
 				} else if el.tail == nil {
 					el.tail = cdt
 				} else {
-					return nil, fmt.Errorf("element head and tail already contain chardata")
+					return nil, errors.New("element head and tail already contain chardata")
 				}
 			}
 		case xml.EndElement:
@@ -533,7 +534,7 @@ func UnmarshalXML(r io.Reader, withIcon bool, minSdkVersion, targetSdkVersion in
 			var el *Element
 			el, bx.stack = bx.stack[n-1], bx.stack[:n-1]
 			if el.end != nil {
-				return nil, fmt.Errorf("element end already exists")
+				return nil, errors.New("element end already exists")
 			}
 			el.end = &ElementEnd{
 				NodeHeader: NodeHeader{
@@ -728,25 +729,25 @@ func (bx *XML) kind(t ResType) (unmarshaler, error) {
 	switch t {
 	case ResStringPool:
 		if bx.Pool != nil {
-			return nil, fmt.Errorf("pool already exists")
+			return nil, errors.New("pool already exists")
 		}
 		bx.Pool = new(Pool)
 		return bx.Pool, nil
 	case ResXMLResourceMap:
 		if bx.Map != nil {
-			return nil, fmt.Errorf("resource map already exists")
+			return nil, errors.New("resource map already exists")
 		}
 		bx.Map = new(Map)
 		return bx.Map, nil
 	case ResXMLStartNamespace:
 		if bx.Namespace != nil {
-			return nil, fmt.Errorf("namespace start already exists")
+			return nil, errors.New("namespace start already exists")
 		}
 		bx.Namespace = new(Namespace)
 		return bx.Namespace, nil
 	case ResXMLEndNamespace:
 		if bx.Namespace.end != nil {
-			return nil, fmt.Errorf("namespace end already exists")
+			return nil, errors.New("namespace end already exists")
 		}
 		bx.Namespace.end = new(Namespace)
 		return bx.Namespace.end, nil
@@ -768,7 +769,7 @@ func (bx *XML) kind(t ResType) (unmarshaler, error) {
 		var el *Element
 		el, bx.stack = bx.stack[n-1], bx.stack[:n-1]
 		if el.end != nil {
-			return nil, fmt.Errorf("element end already exists")
+			return nil, errors.New("element end already exists")
 		}
 		el.end = new(ElementEnd)
 		return el.end, nil
@@ -780,7 +781,7 @@ func (bx *XML) kind(t ResType) (unmarshaler, error) {
 		} else if el.tail == nil {
 			el.tail = cdt
 		} else {
-			return nil, fmt.Errorf("element head and tail already contain chardata")
+			return nil, errors.New("element head and tail already contain chardata")
 		}
 		return cdt, nil
 	default:

--- a/cmd/core/mobile/binres/binres_test.go
+++ b/cmd/core/mobile/binres/binres_test.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"encoding"
 	"encoding/xml"
+	"errors"
 	"fmt"
 	"log"
 	"math"
@@ -102,7 +103,7 @@ func compareBytes(a, b []byte) error {
 			fmt.Fprint(buf, "... output truncated.\n")
 		}
 	}
-	return fmt.Errorf(buf.String())
+	return errors.New(buf.String())
 }
 
 func TestBootstrap(t *testing.T) {
@@ -329,7 +330,7 @@ func compareElements(have, want *XML) error {
 		}
 	}
 	if buf.Len() > 0 {
-		return fmt.Errorf(buf.String())
+		return errors.New(buf.String())
 	}
 	return nil
 }
@@ -358,7 +359,7 @@ func rtou(a []TableRef) (b []uint32) {
 func compareUint32s(t *testing.T, a, b []uint32) error {
 	var err error
 	if len(a) != len(b) {
-		err = fmt.Errorf("lengths do not match")
+		err = errors.New("lengths do not match")
 	}
 
 	n := len(a)
@@ -381,7 +382,7 @@ func compareUint32s(t *testing.T, a, b []uint32) error {
 			d = "__________ "
 		}
 		if err == nil && c != d {
-			err = fmt.Errorf("has missing/incorrect values")
+			err = errors.New("has missing/incorrect values")
 		}
 		buf.WriteString(c + " " + d + "\n")
 	}
@@ -396,7 +397,7 @@ func compareUint32s(t *testing.T, a, b []uint32) error {
 func compareStrings(t *testing.T, a, b []string) error {
 	var err error
 	if len(a) != len(b) {
-		err = fmt.Errorf("lengths do not match")
+		err = errors.New("lengths do not match")
 	}
 
 	buf := new(bytes.Buffer)
@@ -417,7 +418,7 @@ func compareStrings(t *testing.T, a, b []string) error {
 				// TODO this check has the potential to hide real errors but can be fixed once more
 				// of the xml document is unmarshalled and XML can be queried to assure this is related
 				// to platformBuildVersionName.
-				err = fmt.Errorf("has missing/incorrect values")
+				err = errors.New("has missing/incorrect values")
 			}
 		}
 		fmt.Fprintf(buf, "Pool(%2v, %s) %q\n", i, v, x)

--- a/cmd/core/mobile/binres/pool.go
+++ b/cmd/core/mobile/binres/pool.go
@@ -5,6 +5,7 @@
 package binres
 
 import (
+	"errors"
 	"fmt"
 	"unicode/utf16"
 )
@@ -167,7 +168,7 @@ func (pl *Pool) UnmarshalBinary(bin []byte) error {
 
 func (pl *Pool) MarshalBinary() ([]byte, error) {
 	if pl.IsUTF8() {
-		return nil, fmt.Errorf("encode utf8 not supported")
+		return nil, errors.New("encode utf8 not supported")
 	}
 
 	var (

--- a/cmd/core/mobile/binres/sdk.go
+++ b/cmd/core/mobile/binres/sdk.go
@@ -4,6 +4,7 @@ import (
 	"archive/zip"
 	"bytes"
 	"compress/gzip"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -45,7 +46,7 @@ func apiResources() ([]byte, error) {
 		}
 	}
 	if buf.Len() == 0 {
-		return nil, fmt.Errorf("failed to read resources.arsc")
+		return nil, errors.New("failed to read resources.arsc")
 	}
 	return buf.Bytes(), nil
 }

--- a/cmd/core/mobile/binres/table.go
+++ b/cmd/core/mobile/binres/table.go
@@ -525,7 +525,7 @@ func (typ *Type) UnmarshalBinary(bin []byte) error {
 	typ.entriesStart = btou32(bin[16:])
 
 	if typ.res0 != 0 || typ.res1 != 0 {
-		return fmt.Errorf("res0 res1 not zero")
+		return errors.New("res0 res1 not zero")
 	}
 
 	typ.config.size = btou32(bin[20:])

--- a/cmd/core/mobile/build.go
+++ b/cmd/core/mobile/build.go
@@ -105,11 +105,11 @@ func buildImpl(c *config.Config) (*packages.Package, error) {
 	pkg := pkgs[0]
 
 	if pkg.Name != "main" {
-		return nil, fmt.Errorf("cannot build non-main package")
+		return nil, errors.New("cannot build non-main package")
 	}
 
 	if c.ID == "" {
-		return nil, fmt.Errorf("id must be set when building for mobile")
+		return nil, errors.New("id must be set when building for mobile")
 	}
 
 	switch {

--- a/cmd/core/mobile/build_apple.go
+++ b/cmd/core/mobile/build_apple.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"crypto/x509"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -182,7 +183,7 @@ func detectTeamID() (string, error) {
 	}
 
 	if len(cert.Subject.OrganizationalUnit) == 0 {
-		err = fmt.Errorf("the signing certificate has no organizational unit (team ID)")
+		err = errors.New("the signing certificate has no organizational unit (team ID)")
 		return "", err
 	}
 

--- a/filetree/tree.go
+++ b/filetree/tree.go
@@ -396,10 +396,10 @@ func (ft *Tree) externalNodeByPath(fpath string) (*Node, error) {
 	}
 	ekid := ft.ChildByName(externalFilesName, 0)
 	if ekid == nil {
-		return nil, fmt.Errorf("ExtFile not updated -- no ExtFiles node")
+		return nil, errors.New("ExtFile not updated -- no ExtFiles node")
 	}
 	if n := ekid.AsTree().Child(i); n != nil {
 		return AsNode(n), nil
 	}
-	return nil, fmt.Errorf("ExtFile not updated; index invalid")
+	return nil, errors.New("ExtFile not updated; index invalid")
 }

--- a/gpu/texture.go
+++ b/gpu/texture.go
@@ -5,7 +5,6 @@
 package gpu
 
 import (
-	"fmt"
 	"image"
 
 	"cogentcore.org/core/base/errors"
@@ -253,7 +252,7 @@ func (tx *Texture) ConfigReadBuffer() error {
 // [ConfigReadBuffer] prior to start of render pass for this to work.
 func (tx *Texture) CopyToReadBuffer(cmd *wgpu.CommandEncoder) error {
 	if tx.readBuffer == nil {
-		err := fmt.Errorf("gpu.Texture.CopyToReadBuffer: must configure readBuffer prior to render pass")
+		err := errors.New("gpu.Texture.CopyToReadBuffer: must configure readBuffer prior to render pass")
 		return errors.Log(err)
 	}
 	size := tx.Format.Extent3D()
@@ -351,7 +350,7 @@ func (tx *Texture) ReadDataMapped() ([]byte, error) {
 // UnmapReadData unmaps the data from a prior ReadDataMapped call.
 func (tx *Texture) UnmapReadData() error {
 	if tx.readBuffer == nil {
-		return errors.Log(fmt.Errorf("gpu.Texture.UnmapReadData: buffer is nil"))
+		return errors.Log(errors.New("gpu.Texture.UnmapReadData: buffer is nil"))
 	}
 	tx.readBuffer.Unmap()
 	return nil

--- a/gpu/vargroup.go
+++ b/gpu/vargroup.go
@@ -192,7 +192,7 @@ func (vg *VarGroup) Config(dev *Device) error {
 			continue
 		}
 		if vg.Group >= 0 && vr.Role <= Index {
-			err := fmt.Errorf("gpu.VarGroup:Config Vertex or Index Vars must be located in a VertexGroup!  Use AddVertexGroup() method instead of AddGroup()")
+			err := errors.New("gpu.VarGroup:Config Vertex or Index Vars must be located in a VertexGroup!  Use AddVertexGroup() method instead of AddGroup()")
 			errs = append(errs, err)
 			errors.Log(err)
 		}

--- a/svg/xml.go
+++ b/svg/xml.go
@@ -8,7 +8,7 @@ import (
 	"bufio"
 	"bytes"
 	"encoding/xml"
-	"fmt"
+	"errors"
 	"io"
 	"unicode/utf8"
 )
@@ -187,7 +187,7 @@ func (xe *XMLEncoder) EscapeString(s string, escapeNewline bool) {
 
 func (xe *XMLEncoder) WriteStart(start *xml.StartElement) error {
 	if start.Name.Local == "" {
-		return fmt.Errorf("xml: start tag with no name")
+		return errors.New("xml: start tag with no name")
 	}
 	if xe.CurStart != "" {
 		xe.WriteString(">")
@@ -219,7 +219,7 @@ func (xe *XMLEncoder) WriteStart(start *xml.StartElement) error {
 func (xe *XMLEncoder) WriteEnd(name string) error {
 	xe.CurIndent--
 	if name == "" {
-		return fmt.Errorf("xml: end tag with no name")
+		return errors.New("xml: end tag with no name")
 	}
 	if xe.CurStart == name {
 		xe.WriteString(" />")

--- a/texteditor/buffer.go
+++ b/texteditor/buffer.go
@@ -462,7 +462,7 @@ func (tb *Buffer) saveFile(filename core.Filename) error {
 // Save saves the current text into the current filename associated with this buffer.
 func (tb *Buffer) Save() error { //types:add
 	if tb.Filename == "" {
-		return fmt.Errorf("core.Buf: filename is empty for Save")
+		return errors.New("core.Buf: filename is empty for Save")
 	}
 	tb.editDone()
 	info, err := os.Stat(string(tb.Filename))

--- a/xyz/physics/world/world.go
+++ b/xyz/physics/world/world.go
@@ -7,7 +7,6 @@ package world
 //go:generate core generate -add-types
 
 import (
-	"fmt"
 	"image"
 
 	"cogentcore.org/core/base/errors"
@@ -87,7 +86,7 @@ func (vw *View) RenderOffNode(node physics.Node, cam *Camera) error {
 	ok := sc.Render()
 	sc.Geom.Size = sz
 	if !ok {
-		return fmt.Errorf("could not render scene")
+		return errors.New("could not render scene")
 	}
 	return nil
 }

--- a/xyz/physics/world2d/world2d.go
+++ b/xyz/physics/world2d/world2d.go
@@ -7,7 +7,7 @@ package world2d
 //go:generate core generate -add-types
 
 import (
-	"fmt"
+	"errors"
 	"image"
 
 	"cogentcore.org/core/math32"
@@ -77,7 +77,7 @@ func (vw *View) UpdateBodyView(bodyNames ...string) {
 func (vw *View) Image() (*image.RGBA, error) {
 	img := vw.Scene.Pixels
 	if img == nil {
-		return nil, fmt.Errorf("eve2d.View Image: is nil")
+		return nil, errors.New("eve2d.View Image: is nil")
 	}
 	return img, nil
 }

--- a/xyz/render.go
+++ b/xyz/render.go
@@ -5,7 +5,7 @@
 package xyz
 
 import (
-	"fmt"
+	"errors"
 	"image"
 	"sort"
 
@@ -108,7 +108,7 @@ func (sc *Scene) configNewPhong() {
 func (sc *Scene) Image() (*image.RGBA, error) {
 	fr := sc.Frame
 	if fr == nil {
-		return nil, fmt.Errorf("xyz.Scene Image: Scene does not have a Frame")
+		return nil, errors.New("xyz.Scene Image: Scene does not have a Frame")
 	}
 	// sy := &sc.Phong.System
 	// tcmd := sy.MemCmdStart()
@@ -138,7 +138,7 @@ func (sc *Scene) ImageDone() {
 func (sc *Scene) ImageCopy() (*image.RGBA, error) {
 	fr := sc.Frame
 	if fr == nil {
-		return nil, fmt.Errorf("xyz.Scene ImageCopy: Scene does not have a Frame")
+		return nil, errors.New("xyz.Scene ImageCopy: Scene does not have a Frame")
 	}
 	// sy := &sc.Phong.System
 	// tcmd := sy.MemCmdStart()
@@ -175,7 +175,7 @@ func (sc *Scene) AssertImage(t imagex.TestingT, filename string) {
 func (sc *Scene) DepthImage() ([]float32, error) {
 	fr := sc.Frame
 	if fr == nil {
-		return nil, fmt.Errorf("xyz.Scene DepthImage: Scene does not have a Frame")
+		return nil, errors.New("xyz.Scene DepthImage: Scene does not have a Frame")
 	}
 	// sy := &sc.Phong.System
 	// tcmd := sy.MemCmdStart()


### PR DESCRIPTION
replace `fmt.Errorf` by (more efficient) `errors.New` when formatting is not needed.