### PR TITLE
gpu/bind_group: added safe finalizers for CGO allocated objects

### DIFF
--- a/gpu/cpipeline.go
+++ b/gpu/cpipeline.go
@@ -134,8 +134,9 @@ func (pl *ComputePipeline) BindAllGroups(ce *wgpu.ComputePassEncoder) {
 func (pl *ComputePipeline) BindGroup(ce *wgpu.ComputePassEncoder, group int) {
 	vs := pl.Vars()
 	vg := vs.Groups[group]
-	bg, dynOffs, err := vg.bindGroup(vs)
+	bg, release, dynOffs, err := vg.bindGroup(vs)
 	if err == nil {
+		defer release()
 		ce.SetBindGroup(uint32(vg.Group), bg, dynOffs)
 	}
 }

--- a/gpu/gpudraw/draw.go
+++ b/gpu/gpudraw/draw.go
@@ -39,7 +39,7 @@ func (dw *Drawer) Copy(dp image.Point, src image.Image, sr image.Rectangle, op d
 		dr := sr
 		del := dp.Sub(sr.Min)
 		dr.Min = dp
-		dr.Max.Add(del)
+		dr.Max = dr.Max.Add(del)
 		dw.Fill(u.At(0, 0), dr, op)
 		return
 	}

--- a/gpu/gpudraw/system.go
+++ b/gpu/gpudraw/system.go
@@ -197,7 +197,7 @@ func (dw *Drawer) drawAll() error {
 
 	// we should actually run finalizers when everything new is up and running on GPU.
 	if err := finalizers.Finalize(); err != nil {
-		return fmt.Errorf("Drawer.drawAll: finalizator failed: %w", err)
+		return fmt.Errorf("Drawer.drawAll: finalizer failed: %w", err)
 	}
 
 	return nil

--- a/gpu/gpudraw/system.go
+++ b/gpu/gpudraw/system.go
@@ -154,7 +154,7 @@ func (dw *Drawer) drawAll() error {
 		return err
 	}
 
-	// finalizers is a collection of postponed finalizer for objects allocated in CGO world.
+	// finalizers is a collection of postponed finalizers for objects allocated in CGO world.
 	var finalizers memoryFinalizer
 
 	imgIdx := 0


### PR DESCRIPTION
This is actual for the Bind Group.

Fixes https://github.com/cogentcore/core/issues/1430