### PR TITLE
record and release old wgpu BindGroup items, which were otherwise not being released.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,10 +12,9 @@ require (
 	github.com/bramvdbogaerde/go-scp v1.4.0
 	github.com/chewxy/math32 v1.10.1
 	github.com/cogentcore/reisen v0.0.0-20240814194831-4d884b6e7666
-	github.com/cogentcore/webgpu v0.0.0-20241212004832-ad7475f3b4dd
+	github.com/cogentcore/webgpu v0.0.0-20250117020559-3809548f4891
 	github.com/cogentcore/yaegi v0.0.0-20240724064145-e32a03faad56
 	github.com/coreos/go-oidc/v3 v3.10.0
-	github.com/ergochat/readline v0.1.2
 	github.com/ericchiang/css v1.3.0
 	github.com/faiface/beep v1.1.0
 	github.com/fsnotify/fsnotify v1.7.0
@@ -30,7 +29,6 @@ require (
 	github.com/mattn/go-shellwords v1.0.12
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/muesli/termenv v0.15.2
-	github.com/nsf/termbox-go v1.1.1
 	github.com/pelletier/go-toml/v2 v2.1.2-0.20240227203013-2b69615b5d55
 	github.com/stretchr/testify v1.9.0
 	golang.org/x/crypto v0.31.0
@@ -40,7 +38,6 @@ require (
 	golang.org/x/oauth2 v0.20.0
 	golang.org/x/sys v0.28.0
 	golang.org/x/tools v0.23.0
-	gonum.org/v1/gonum v0.15.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -25,8 +25,8 @@ github.com/chewxy/math32 v1.10.1 h1:LFpeY0SLJXeaiej/eIp2L40VYfscTvKh/FSEZ68uMkU=
 github.com/chewxy/math32 v1.10.1/go.mod h1:dOB2rcuFrCn6UHrze36WSLVPKtzPMRAQvBvUwkSsLqs=
 github.com/cogentcore/reisen v0.0.0-20240814194831-4d884b6e7666 h1:gmXMw/Xcva/2V5qRO920q4am1odNE0xFEGBzG7y7cus=
 github.com/cogentcore/reisen v0.0.0-20240814194831-4d884b6e7666/go.mod h1:HoDh/nWYrLffGjfVxUmbJHb0yZvcV3TwrN73WurddNs=
-github.com/cogentcore/webgpu v0.0.0-20241212004832-ad7475f3b4dd h1:wmOdOGOfQDY/hmiQTWzoM59SskQSjrMz91jWv0gt6Yg=
-github.com/cogentcore/webgpu v0.0.0-20241212004832-ad7475f3b4dd/go.mod h1:ciqaxChrmRRMU1SnI5OE12Cn3QWvOKO+e5nSy+N9S1o=
+github.com/cogentcore/webgpu v0.0.0-20250117020559-3809548f4891 h1:cIwWHCSlztHgtm6YSrKuRJqeLVtski0jXttMa1j4TLc=
+github.com/cogentcore/webgpu v0.0.0-20250117020559-3809548f4891/go.mod h1:ciqaxChrmRRMU1SnI5OE12Cn3QWvOKO+e5nSy+N9S1o=
 github.com/cogentcore/yaegi v0.0.0-20240724064145-e32a03faad56 h1:Fz1uHiFCHnijFcMXzn36KLamcx5q4pxoR5rKCrcXIcQ=
 github.com/cogentcore/yaegi v0.0.0-20240724064145-e32a03faad56/go.mod h1:+MGpZ0srBmeJ7aaOLTdVss8WLolt0/y/plVHLpxgd3A=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
@@ -43,8 +43,6 @@ github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dlclark/regexp2 v1.11.0 h1:G/nrcoOa7ZXlpoa/91N3X7mM3r8eIlMBBJZvsz/mxKI=
 github.com/dlclark/regexp2 v1.11.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
-github.com/ergochat/readline v0.1.2 h1:zxiwQB8DyTLD0HSWthJlnvs5E2X1qnyXZ44RFf1jRlg=
-github.com/ergochat/readline v0.1.2/go.mod h1:o3ux9QLHLm77bq7hDB21UTm6HlV2++IPDMfIfKDuOgY=
 github.com/ericchiang/css v1.3.0 h1:e0vS+vpujMjtT3/SYu7qTHn1LVzXWcLCCDjlfq3YlLY=
 github.com/ericchiang/css v1.3.0/go.mod h1:sVSdL+MFR9Q4cKJMQzpIkHIDOLiK+7Wmjjhq7D+MubA=
 github.com/faiface/beep v1.1.0 h1:A2gWP6xf5Rh7RG/p9/VAW2jRSDEGQm5sbOb38sf5d4c=
@@ -110,7 +108,6 @@ github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czP
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mattn/go-runewidth v0.0.4/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
-github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/mattn/go-runewidth v0.0.15 h1:UNAjwbU9l54TA3KzvqLGxwWjHmMgBUVhBiTjelZgg3U=
 github.com/mattn/go-runewidth v0.0.15/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
 github.com/mattn/go-shellwords v1.0.12 h1:M2zGm7EW6UQJvDeQxo4T51eKPurbeFbe8WtebGE2xrk=
@@ -124,8 +121,6 @@ github.com/muesli/termenv v0.15.2 h1:GohcuySI0QmI3wN8Ok9PtKGkgkFIk7y6Vpb5PvrY+Wo
 github.com/muesli/termenv v0.15.2/go.mod h1:Epx+iuz8sNs7mNKhxzH4fWXGNpZwUaJKRS1noLXviQ8=
 github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646 h1:zYyBkD/k9seD2A7fsi6Oo2LfFZAehjjQMERAvZLEDnQ=
 github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646/go.mod h1:jpp1/29i3P1S/RLdc7JQKbRpFeM1dOBd8T9ki5s+AY8=
-github.com/nsf/termbox-go v1.1.1 h1:nksUPLCb73Q++DwbYUBEglYBRPZyoXJdrj5L+TkjyZY=
-github.com/nsf/termbox-go v1.1.1/go.mod h1:T0cTdVuOwf7pHQNtfhnEbzHbcNyCEcVU4YPpouCbVxo=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pelletier/go-toml/v2 v2.1.2-0.20240227203013-2b69615b5d55 h1:CJwoX/v1ZWNj0Ofn62jvQDRuH3/hIHMqCQxbkzq2m5Y=
 github.com/pelletier/go-toml/v2 v2.1.2-0.20240227203013-2b69615b5d55/go.mod h1:tJU2Z3ZkXwnxa4DPO899bsyIoywizdUvyaeZurnPPDc=
@@ -204,8 +199,6 @@ golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGm
 golang.org/x/tools v0.23.0 h1:SGsXPZ+2l4JsgaCKkx+FQ9YZ5XEtA1GZYuoDjenLjvg=
 golang.org/x/tools v0.23.0/go.mod h1:pnu6ufv6vQkll6szChhK3C3L/ruaIv5eBeztNG8wtsI=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
-gonum.org/v1/gonum v0.15.0 h1:2lYxjRbTYyxkJxlhC+LvJIx3SsANPdRybu1tGj9/OrQ=
-gonum.org/v1/gonum v0.15.0/go.mod h1:xzZVBJBtS+Mz4q0Yl2LJTk+OxOg4jiXZ7qBoM0uISGo=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=

--- a/gpu/compute.go
+++ b/gpu/compute.go
@@ -157,6 +157,7 @@ func (sy *ComputeSystem) EndComputePass() error {
 	sy.device.Queue.Submit(cmdBuffer)
 	cmdBuffer.Release()
 	cmd.Release()
+	sy.vars.releaseOldBindGroups()
 	return nil
 }
 

--- a/gpu/gpudraw/draw.go
+++ b/gpu/gpudraw/draw.go
@@ -39,7 +39,7 @@ func (dw *Drawer) Copy(dp image.Point, src image.Image, sr image.Rectangle, op d
 		dr := sr
 		del := dp.Sub(sr.Min)
 		dr.Min = dp
-		dr.Max.Add(del)
+		dr.Max = dr.Max.Add(del)
 		dw.Fill(u.At(0, 0), dr, op)
 		return
 	}

--- a/gpu/gsystem.go
+++ b/gpu/gsystem.go
@@ -269,6 +269,7 @@ func (sy *GraphicsSystem) SubmitRender(rp *wgpu.RenderPassEncoder) error {
 	sy.device.Queue.Submit(cmdBuffer)
 	cmdBuffer.Release()
 	cmd.Release()
+	sy.vars.releaseOldBindGroups()
 	return nil
 }
 

--- a/gpu/pipeline.go
+++ b/gpu/pipeline.go
@@ -131,3 +131,12 @@ func (pl *Pipeline) bindLayout() (*wgpu.PipelineLayout, error) {
 	}
 	return rpl, nil
 }
+
+func (pl *Pipeline) releaseOldBindGroups() {
+	vs := pl.Vars()
+	ngp := vs.NGroups()
+	for gi := range ngp {
+		vg := vs.Groups[gi]
+		vg.releaseOldBindGroups()
+	}
+}

--- a/gpu/value.go
+++ b/gpu/value.go
@@ -279,7 +279,7 @@ func (vl *Value) SetFromBytes(from []byte) error {
 		return errors.Log(err)
 	}
 	if vl.buffer == nil || vl.AllocSize != tb {
-		vl.varGroupDirty()
+		vl.varGroupDirty() // only if tb is different; buffer created in bindGroupEntry so not nil here
 		vl.Release()
 		buf, err := vl.device.Device.CreateBufferInit(&wgpu.BufferInitDescriptor{
 			Label:    vl.Name,
@@ -355,7 +355,7 @@ func (vl *Value) WriteDynamicBuffer() error {
 		return errors.Log(err)
 	}
 	if vl.buffer == nil || nb != vl.AllocSize {
-		vl.varGroupDirty()
+		vl.varGroupDirty() // only if nb is different; buffer created in bindGroupEntry so not nil here
 		vl.Release()
 		buf, err := vl.device.Device.CreateBufferInit(&wgpu.BufferInitDescriptor{
 			Label:    vl.Name,

--- a/gpu/vargroup.go
+++ b/gpu/vargroup.go
@@ -242,6 +242,10 @@ func (vg *VarGroup) releaseOldBindGroups() {
 // Release destroys infrastructure for Group, Vars and Values.
 func (vg *VarGroup) Release() {
 	vg.releaseOldBindGroups()
+	if vg.currentBindGroup != nil {
+		vg.currentBindGroup.Release()
+		vg.currentBindGroup = nil
+	}
 	for _, vr := range vg.Vars {
 		vr.Release()
 	}

--- a/gpu/vargroup.go
+++ b/gpu/vargroup.go
@@ -66,6 +66,10 @@ type VarGroup struct {
 
 	// current bind group
 	currentBindGroup *wgpu.BindGroup
+
+	// oldBindGroups are prior bind groups that need to be released
+	// after current render or compute pass.
+	oldBindGroups []*wgpu.BindGroup
 }
 
 // addVar adds given variable
@@ -223,8 +227,21 @@ func (vg *VarGroup) Config(dev *Device) error {
 	return errors.Join(errs...)
 }
 
+// releaseOldBindGroups releases old bind groups.
+func (vg *VarGroup) releaseOldBindGroups() {
+	if vg.oldBindGroups == nil {
+		return
+	}
+	og := vg.oldBindGroups
+	vg.oldBindGroups = nil
+	for _, bg := range og {
+		bg.Release()
+	}
+}
+
 // Release destroys infrastructure for Group, Vars and Values.
 func (vg *VarGroup) Release() {
+	vg.releaseOldBindGroups()
 	for _, vr := range vg.Vars {
 		vr.Release()
 	}
@@ -318,7 +335,10 @@ func (vg *VarGroup) bindGroup(vs *Vars) (*wgpu.BindGroup, []uint32, error) {
 		return vg.currentBindGroup, dynamicOffsets, nil
 	}
 	vg.bindGroupDirty = false
-	vg.currentBindGroup = nil // critically, we do NOT release this!
+	if vg.currentBindGroup != nil {
+		vg.oldBindGroups = append(vg.oldBindGroups, vg.currentBindGroup) // to be released
+	}
+	vg.currentBindGroup = nil
 	bgl, err := vg.bindLayout(vs)
 	if err != nil {
 		return nil, nil, err

--- a/gpu/vars.go
+++ b/gpu/vars.go
@@ -48,6 +48,12 @@ func (vs *Vars) Release() {
 	}
 }
 
+func (vs *Vars) releaseOldBindGroups() {
+	for _, vg := range vs.Groups {
+		vg.releaseOldBindGroups()
+	}
+}
+
 // AddVertexGroup adds a new Vertex Group.
 // This is a special Group holding Vertex, Index vars
 func (vs *Vars) AddVertexGroup() *VarGroup {


### PR DESCRIPTION
Thanks to @AnyCPU for identifying leak and potential fix in #1434, and @StinkyPeach for reporting the issue.

Relevant to #1430

note that with screen zoom that there is a remaining issue associated with loading fonts for each different DPI size, which is not fixed with this PR, and will not be addressed until we do the vello and go-text refactor.

