### PR TITLE
border: fix leak of border styles. 

### DIFF
--- a/core/render_test.go
+++ b/core/render_test.go
@@ -79,6 +79,27 @@ func TestRenderParentBorderRadiusHorizontalToolbar(t *testing.T) {
 	b.AssertRender(t, "render/parent-border-radius-horizontal-toolbar")
 }
 
+func TestRenderBorderLeak(t *testing.T) {
+	b := NewBody()
+	NewFrame(b).Styler(func(s *styles.Style) {
+		s.Min.Set(units.Em(5))
+		s.Border.Width.Set(units.Dp(4))
+		s.Border.Color.Set(colors.Scheme.Outline)
+	})
+	NewFrame(b).Styler(func(s *styles.Style) {
+		s.Min.Set(units.Em(5))
+		s.Border.Style.Set(styles.BorderDotted)
+		s.Border.Width.Set(units.Dp(4))
+		s.Border.Color.Set(colors.Scheme.Error.Base)
+	})
+	NewFrame(b).Styler(func(s *styles.Style) {
+		s.Min.Set(units.Em(5))
+		s.Border.Width.Set(units.Dp(4))
+		s.Border.Color.Set(colors.Scheme.Outline)
+	})
+	b.AssertRender(t, "render/border-leak")
+}
+
 // For https://github.com/cogentcore/core/issues/810
 func TestRenderButtonAlignment(t *testing.T) {
 	b := NewBody()

--- a/paint/paint.go
+++ b/paint/paint.go
@@ -519,6 +519,12 @@ func (pc *Context) DrawPolygonPxToDots(points []math32.Vector2) {
 // DrawBorder is a higher-level function that draws, strokes, and fills
 // an potentially rounded border box with the given position, size, and border styles.
 func (pc *Context) DrawBorder(x, y, w, h float32, bs styles.Border) {
+	origStroke := pc.StrokeStyle
+	origFill := pc.FillStyle
+	defer func() {
+		pc.StrokeStyle = origStroke
+		pc.FillStyle = origFill
+	}()
 	r := bs.Radius.Dots()
 	if styles.SidesAreSame(bs.Style) && styles.SidesAreSame(bs.Color) && styles.SidesAreSame(bs.Width.Dots().Sides) {
 		// set the color if it is not nil and the stroke style


### PR DESCRIPTION
In paint, any time we set StrokeStyle to something other than the actual styled values, we need to save and restore original! added test.
