### PR TITLE
Improve the behavior of AsyncLock

### DIFF
--- a/core/render.go
+++ b/core/render.go
@@ -31,7 +31,7 @@ import (
 // context is not available, then this will block forever. Enable
 // [DebugSettingsData.UpdateTrace] in [DebugSettings] to see when that happens.
 // If the scene has not been shown yet and the render context is nil, it will wait
-// until the scene is shown.
+// until the scene is shown before trying again.
 func (wb *WidgetBase) AsyncLock() {
 	rc := wb.Scene.renderContext()
 	if rc == nil {
@@ -43,7 +43,8 @@ func (wb *WidgetBase) AsyncLock() {
 			}
 			select {}
 		}
-		// Otherwise, if we haven't been shown yet, we just wait until we are.
+		// Otherwise, if we haven't been shown yet, we just wait until we are
+		// and then try again.
 		if DebugSettings.UpdateTrace {
 			fmt.Println("AsyncLock: waiting for scene to be shown:", wb)
 		}
@@ -52,6 +53,8 @@ func (wb *WidgetBase) AsyncLock() {
 			onShow <- struct{}{}
 		})
 		<-onShow
+		wb.AsyncLock() // try again
+		return
 	}
 	rc.lock()
 	if wb.This == nil {

--- a/core/render.go
+++ b/core/render.go
@@ -30,6 +30,8 @@ import (
 // If the widget has been deleted, or if the [Scene] has been shown but the render
 // context is not available, then this will block forever. Enable
 // [DebugSettingsData.UpdateTrace] in [DebugSettings] to see when that happens.
+// If the scene has not been shown yet and the render context is nil, it will wait
+// until the scene is shown.
 func (wb *WidgetBase) AsyncLock() {
 	rc := wb.Scene.renderContext()
 	if rc == nil {

--- a/core/render.go
+++ b/core/render.go
@@ -26,11 +26,14 @@ import (
 // AsyncLock must be called before making any updates in a separate goroutine
 // outside of the main configuration, rendering, and event handling structure.
 // It must have a matching [WidgetBase.AsyncUnlock] after it.
+//
+// If the widget has been deleted, or if the [Scene] has been shown and the render
+// context is not available, then this will block forever.
 func (wb *WidgetBase) AsyncLock() {
 	rc := wb.Scene.renderContext()
-	if rc == nil {
-		// if there is no render context, we are probably
-		// being deleted, so we just block forever
+	if rc == nil && wb.Scene.hasFlag(sceneHasShown) {
+		// If there is no render context and the scene is shown,
+		// we are probably being deleted, so we just block forever.
 		select {}
 	}
 	rc.lock()

--- a/core/render.go
+++ b/core/render.go
@@ -29,7 +29,7 @@ import (
 //
 // If the widget has been deleted, or if the [Scene] has been shown but the render
 // context is not available, then this will block forever. Enable
-// [DebugSettingsData.UpdateTrace] to see when that happens.
+// [DebugSettingsData.UpdateTrace] in [DebugSettings] to see when that happens.
 func (wb *WidgetBase) AsyncLock() {
 	rc := wb.Scene.renderContext()
 	if rc == nil && wb.Scene.hasFlag(sceneHasShown) {


### PR DESCRIPTION
When the render context is nil but the scene has not yet been shown, we try again after the scene is shown instead of blocking forever. Also improve documentation and add debug statements.

This fixes an issue where lazily loaded images in htmlcore would not display sometimes, particularly on Linux.