### PR TITLE
window: fixed boolean errors in if conditions

### DIFF
--- a/core/windowgeometry.go
+++ b/core/windowgeometry.go
@@ -261,7 +261,6 @@ func (ws *windowGeometrySaver) record(win *renderWindow) {
 	}
 	sc := win.SystemWindow.Screen()
 	pos := win.SystemWindow.Position(sc)
-
 	ws.mu.Lock()
 	if ws.settingNoSave {
 		if DebugSettings.WindowGeometryTrace {

--- a/core/windowgeometry.go
+++ b/core/windowgeometry.go
@@ -257,7 +257,8 @@ func (ws *windowGeometrySaver) record(win *renderWindow) {
 	}
 	sc := win.SystemWindow.Screen()
 	pos := win.SystemWindow.Position(sc)
-	if TheApp.Platform() == system.Windows && pos.X == -32000 || pos.Y == -32000 { // windows badness
+	// TODO: come up with better name for a -32000 constant
+	if TheApp.Platform() == system.Windows && (pos.X == -32000 || pos.Y == -32000) { // windows badness
 		if DebugSettings.WindowGeometryTrace {
 			log.Printf("WindowGeometry: Record: NOT storing very negative pos: %v for win: %v\n", pos, win.name)
 		}

--- a/core/windowgeometry.go
+++ b/core/windowgeometry.go
@@ -243,9 +243,13 @@ func (ws *windowGeometrySaver) settingEnd() {
 
 // record records current state of window as preference
 func (ws *windowGeometrySaver) record(win *renderWindow) {
-	if !ws.shouldSave() || !win.isVisible() || win.SystemWindow.Is(system.Fullscreen) {
+	if !ws.shouldSave() ||
+		!win.isVisible() ||
+		win.SystemWindow.Is(system.Fullscreen) ||
+		win.SystemWindow.Is(system.Minimized) {
 		return
 	}
+
 	win.SystemWindow.Lock()
 	wsz := win.SystemWindow.Size()
 	win.SystemWindow.Unlock()
@@ -257,13 +261,7 @@ func (ws *windowGeometrySaver) record(win *renderWindow) {
 	}
 	sc := win.SystemWindow.Screen()
 	pos := win.SystemWindow.Position(sc)
-	// TODO: come up with better name for a -32000 constant
-	if TheApp.Platform() == system.Windows && (pos.X == -32000 || pos.Y == -32000) { // windows badness
-		if DebugSettings.WindowGeometryTrace {
-			log.Printf("WindowGeometry: Record: NOT storing very negative pos: %v for win: %v\n", pos, win.name)
-		}
-		return
-	}
+
 	ws.mu.Lock()
 	if ws.settingNoSave {
 		if DebugSettings.WindowGeometryTrace {

--- a/system/driver/desktop/window.go
+++ b/system/driver/desktop/window.go
@@ -308,13 +308,13 @@ func (w *Window) SetGeometry(fullscreen bool, pos, size image.Point, screen *sys
 }
 
 func (w *Window) ConstrainFrame(topOnly bool) styles.Sides[int] {
-	if w.IsClosed() || w.Is(system.Fullscreen) || w.Is(system.Maximized) {
+	if w.IsClosed() ||
+		w.Is(system.Fullscreen) ||
+		w.Is(system.Maximized) ||
+		w.Is(system.Minimized) {
 		return w.FrameSize
 	}
-	// TODO: come up with better name for a -32000 constant
-	if TheApp.Platform() == system.Windows && (w.Pos.X == -32000 || w.Pos.Y == -32000) {
-		return w.FrameSize
-	}
+
 	l, t, r, b := w.Glw.GetFrameSize()
 	w.FrameSize.Set(t, r, b, l)
 	sc := w.Screen()

--- a/system/driver/desktop/window.go
+++ b/system/driver/desktop/window.go
@@ -311,7 +311,8 @@ func (w *Window) ConstrainFrame(topOnly bool) styles.Sides[int] {
 	if w.IsClosed() || w.Is(system.Fullscreen) || w.Is(system.Maximized) {
 		return w.FrameSize
 	}
-	if TheApp.Platform() == system.Windows && w.Pos.X == -32000 || w.Pos.Y == -32000 {
+	// TODO: come up with better name for a -32000 constant
+	if TheApp.Platform() == system.Windows && (w.Pos.X == -32000 || w.Pos.Y == -32000) {
 		return w.FrameSize
 	}
 	l, t, r, b := w.Glw.GetFrameSize()

--- a/system/screen.go
+++ b/system/screen.go
@@ -176,12 +176,10 @@ func (sc *Screen) WindowSizeFromPixels(sz image.Point) image.Point {
 func (sc *Screen) ConstrainWindowGeometry(pos, sz image.Point) (cpos, csz image.Point) {
 	scSize := sc.Geometry.Size() // in window coords size
 	if TheApp.Platform() == Windows {
-		// these are windows-specific special numbers for minimized windows
-		// can be sent here for WinGeom saved geom.
-		if pos.X == -32000 {
+		if pos.X == WindowsMinimizedPosition {
 			pos.X = 0
 		}
-		if pos.Y == -32000 {
+		if pos.Y == WindowsMinimizedPosition {
 			pos.Y = 50
 		}
 	}

--- a/system/window.go
+++ b/system/window.go
@@ -373,3 +373,4 @@ func (o *NewWindowOptions) Fixup() {
 		o.Pos, o.Size = sc.ConstrainWindowGeometry(o.Pos, o.Size) // make sure ok
 	}
 }
+

--- a/system/window_position.go
+++ b/system/window_position.go
@@ -1,0 +1,9 @@
+// Copyright (c) 2018, Cogent Core. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package system
+
+// this is windows-specific special number for minimized windows.
+// ad-hoc way to figure out whether a window is minimized or not.
+const WindowsMinimizedPosition = -32000


### PR DESCRIPTION
affected functions: Window.ConstrainFrame and windowGeometrySaver.record.

Fixes https://github.com/cogentcore/core/issues/1465