### PR TITLE
window/screens: fixed a nil reference panic while switching RDP sessions

### DIFF
--- a/system/driver/base/app_multi.go
+++ b/system/driver/base/app_multi.go
@@ -50,6 +50,10 @@ func (a *AppMulti[W]) Screen(n int) *system.Screen {
 	if n >= 0 && n < len(a.Screens) {
 		return a.Screens[n]
 	}
+
+	// this is pretty dangerous and it might panic
+	// because Screens slice might have zero length at some point of time.
+	// fail fast keeps it as is.
 	return a.Screens[0]
 }
 

--- a/system/driver/desktop/window.go
+++ b/system/driver/desktop/window.go
@@ -150,7 +150,7 @@ func (w *Window) Screen() *system.Screen {
 		}
 	}
 
-	// trying to get a onf of actual screens safely
+	// trying to get a one of actual screens safely
 	// because a `Screen(n int) *system.Screen` may panic.
 	if sc == nil && len(TheApp.Screens) > 0 {
 		sc = TheApp.Screens[0]

--- a/system/driver/desktop/window.go
+++ b/system/driver/desktop/window.go
@@ -128,7 +128,7 @@ func (w *Window) newGlfwWindow(opts *system.NewWindowOptions, sc *system.Screen)
 // Screen gets the screen of the window, computing various window parameters.
 func (w *Window) Screen() *system.Screen {
 	if w == nil || w.Glw == nil {
-		return TheApp.Screens[0] // cool guys do not look aat panics
+		return TheApp.Screens[0] // cool guys do not look at panics
 	}
 
 	w.Mu.Lock()


### PR DESCRIPTION
Fixes https://github.com/cogentcore/core/issues/1467