### PR TITLE
Improve navigation options in Cogent Content

### DIFF
--- a/content/buttons.go
+++ b/content/buttons.go
@@ -5,6 +5,8 @@
 package content
 
 import (
+	"slices"
+
 	"cogentcore.org/core/colors"
 	"cogentcore.org/core/core"
 	"cogentcore.org/core/events"
@@ -73,4 +75,53 @@ func (ct *Content) MenuSearch(items *[]core.ChooserItem) {
 		}
 	}
 	*items = append(newItems, *items...)
+}
+
+// makeBottomButtons makes the previous and next buttons if relevant.
+func (ct *Content) makeBottomButtons(p *tree.Plan) {
+	if len(ct.currentPage.Categories) == 0 {
+		return
+	}
+	cat := ct.currentPage.Categories[0]
+	pages := ct.pagesByCategory[cat]
+	idx := slices.Index(pages, ct.currentPage)
+
+	ct.prevPage, ct.nextPage = nil, nil
+
+	if idx > 0 {
+		ct.prevPage = pages[idx-1]
+	}
+	if idx < len(pages)-1 {
+		ct.nextPage = pages[idx+1]
+	}
+
+	if ct.prevPage == nil && ct.nextPage == nil {
+		return
+	}
+
+	tree.Add(p, func(w *core.Frame) {
+		w.Styler(func(s *styles.Style) {
+			s.Align.Items = styles.Center
+			s.Grow.Set(1, 0)
+		})
+		w.Maker(func(p *tree.Plan) {
+			if ct.prevPage != nil {
+				tree.Add(p, func(w *core.Button) {
+					w.SetText("Previous").SetIcon(icons.ArrowBack).SetType(core.ButtonTonal)
+					ct.Context.LinkButtonUpdating(w, func() string { // needed to prevent stale URL variable
+						return ct.prevPage.URL
+					})
+				})
+			}
+			if ct.nextPage != nil {
+				tree.Add(p, func(w *core.Stretch) {})
+				tree.Add(p, func(w *core.Button) {
+					w.SetText("Next").SetIcon(icons.ArrowForward).SetType(core.ButtonTonal)
+					ct.Context.LinkButtonUpdating(w, func() string { // needed to prevent stale URL variable
+						return ct.nextPage.URL
+					})
+				})
+			}
+		})
+	})
 }

--- a/content/buttons.go
+++ b/content/buttons.go
@@ -18,6 +18,20 @@ import (
 )
 
 func (ct *Content) MakeToolbar(p *tree.Plan) {
+	if ct.SizeClass() == core.SizeCompact {
+		tree.Add(p, func(w *core.Button) {
+			w.SetIcon(icons.Menu)
+			w.SetTooltip("Navigate pages and headings")
+			w.OnClick(func(e events.Event) {
+				d := core.NewBody("Navigate")
+				// tree.MoveToParent(ct.leftFrame, d)
+				d.AddBottomBar(func(bar *core.Frame) {
+					d.AddCancel(bar)
+				})
+				d.RunDialog(w)
+			})
+		})
+	}
 	tree.Add(p, func(w *core.Button) {
 		w.SetIcon(icons.Icon(core.AppIcon))
 		w.SetTooltip("Home")

--- a/content/buttons.go
+++ b/content/buttons.go
@@ -18,7 +18,7 @@ import (
 )
 
 func (ct *Content) MakeToolbar(p *tree.Plan) {
-	if ct.SizeClass() == core.SizeCompact {
+	if false && ct.SizeClass() == core.SizeCompact { // TODO: implement hamburger menu for compact
 		tree.Add(p, func(w *core.Button) {
 			w.SetIcon(icons.Menu)
 			w.SetTooltip("Navigate pages and headings")

--- a/content/content.go
+++ b/content/content.go
@@ -338,6 +338,8 @@ func (ct *Content) makeTableOfContents(w *core.Frame) {
 	contents.OnSelect(func(e events.Event) {
 		if contents.IsRootSelected() {
 			ct.rightFrame.ScrollDimToContentStart(math32.Y)
+			ct.currentHeading = ""
+			ct.saveWebURL()
 		}
 	})
 	// last is the most recent tree node for each heading level, used for nesting.

--- a/content/content.go
+++ b/content/content.go
@@ -447,7 +447,7 @@ func (ct *Content) MakeToolbar(p *tree.Plan) {
 	tree.Add(p, func(w *core.Button) {
 		w.SetText("Search").SetIcon(icons.Search).SetKey(keymap.Menu)
 		w.Styler(func(s *styles.Style) {
-			s.Background = colors.Scheme.SurfaceContainerHighest
+			s.Background = colors.Scheme.SurfaceVariant
 			s.Padding.Right.Em(5)
 		})
 		w.OnClick(func(e events.Event) {

--- a/content/content.go
+++ b/content/content.go
@@ -374,6 +374,10 @@ func (ct *Content) makeCategories() {
 	cats := core.NewTree(ct.leftFrame).SetText("<b>Categories</b>")
 	for _, cat := range ct.categories {
 		catTree := core.NewTree(cats).SetText(cat).SetClosed(true)
+		if ct.currentPage.Name == cat {
+			catTree.SetSelected(true)
+			catTree.SetClosed(false) // needs to happen after SetSelected since that overrides
+		}
 		catTree.OnSelect(func(e events.Event) {
 			if catPage := ct.pageByName(cat); catPage != nil {
 				ct.Open(catPage.URL)

--- a/content/content.go
+++ b/content/content.go
@@ -20,6 +20,7 @@ import (
 	"cogentcore.org/core/base/errors"
 	"cogentcore.org/core/base/fsx"
 	"cogentcore.org/core/base/strcase"
+	"cogentcore.org/core/colors"
 	"cogentcore.org/core/content/bcontent"
 	"cogentcore.org/core/core"
 	"cogentcore.org/core/events"
@@ -444,8 +445,11 @@ func (ct *Content) MakeToolbar(p *tree.Plan) {
 		})
 	}
 	tree.Add(p, func(w *core.Button) {
-		w.SetIcon(icons.Search).SetKey(keymap.Menu)
-		w.SetTooltip("Search")
+		w.SetText("Search").SetIcon(icons.Search).SetKey(keymap.Menu)
+		w.Styler(func(s *styles.Style) {
+			s.Background = colors.Scheme.SurfaceContainerHighest
+			s.Padding.Right.Em(5)
+		})
 		w.OnClick(func(e events.Event) {
 			ct.Scene.MenuSearchDialog("Search", "Search "+core.TheApp.Name())
 		})

--- a/content/content.go
+++ b/content/content.go
@@ -296,6 +296,7 @@ func (ct *Content) open(url string, history bool) {
 
 func (ct *Content) openHeading(heading string) {
 	if heading == "" {
+		ct.rightFrame.ScrollDimToContentStart(math32.Y)
 		return
 	}
 	tr := ct.tocNodes[strcase.ToKebab(heading)]
@@ -321,7 +322,6 @@ func (ct *Content) loadPage(w *core.Frame) error {
 		return err
 	}
 
-	ct.rightFrame.ScrollDimToContentStart(math32.Y)
 	ct.leftFrame.DeleteChildren()
 	ct.makeTableOfContents(w)
 	ct.makeCategories()

--- a/content/content.go
+++ b/content/content.go
@@ -378,7 +378,6 @@ func (ct *Content) makeCategories() {
 		catTree := core.NewTree(cats).SetText(cat).SetClosed(true)
 		if ct.currentPage.Name == cat {
 			catTree.SetSelected(true)
-			catTree.SetClosed(false) // needs to happen after SetSelected since that overrides
 		}
 		catTree.OnSelect(func(e events.Event) {
 			if catPage := ct.pageByName(cat); catPage != nil {

--- a/content/content.go
+++ b/content/content.go
@@ -24,13 +24,10 @@ import (
 	"cogentcore.org/core/base/errors"
 	"cogentcore.org/core/base/fsx"
 	"cogentcore.org/core/base/strcase"
-	"cogentcore.org/core/colors"
 	"cogentcore.org/core/content/bcontent"
 	"cogentcore.org/core/core"
 	"cogentcore.org/core/events"
 	"cogentcore.org/core/htmlcore"
-	"cogentcore.org/core/icons"
-	"cogentcore.org/core/keymap"
 	"cogentcore.org/core/math32"
 	"cogentcore.org/core/styles"
 	"cogentcore.org/core/system"
@@ -427,64 +424,4 @@ func (ct *Content) setStageTitle() {
 		}
 		rw.SetStageTitle(name)
 	}
-}
-
-func (ct *Content) MakeToolbar(p *tree.Plan) {
-	tree.Add(p, func(w *core.Button) {
-		w.SetIcon(icons.Icon(core.AppIcon))
-		w.SetTooltip("Home")
-		w.OnClick(func(e events.Event) {
-			ct.Open("")
-		})
-	})
-	// Superseded by browser navigation on web.
-	if core.TheApp.Platform() != system.Web {
-		tree.Add(p, func(w *core.Button) {
-			w.SetIcon(icons.ArrowBack).SetKey(keymap.HistPrev)
-			w.SetTooltip("Back")
-			w.Updater(func() {
-				w.SetEnabled(ct.historyIndex > 0)
-			})
-			w.OnClick(func(e events.Event) {
-				ct.historyIndex--
-				ct.open(ct.history[ct.historyIndex].URL, false) // do not add to history while navigating history
-			})
-		})
-		tree.Add(p, func(w *core.Button) {
-			w.SetIcon(icons.ArrowForward).SetKey(keymap.HistNext)
-			w.SetTooltip("Forward")
-			w.Updater(func() {
-				w.SetEnabled(ct.historyIndex < len(ct.history)-1)
-			})
-			w.OnClick(func(e events.Event) {
-				ct.historyIndex++
-				ct.open(ct.history[ct.historyIndex].URL, false) // do not add to history while navigating history
-			})
-		})
-	}
-	tree.Add(p, func(w *core.Button) {
-		w.SetText("Search").SetIcon(icons.Search).SetKey(keymap.Menu)
-		w.Styler(func(s *styles.Style) {
-			s.Background = colors.Scheme.SurfaceVariant
-			s.Padding.Right.Em(5)
-		})
-		w.OnClick(func(e events.Event) {
-			ct.Scene.MenuSearchDialog("Search", "Search "+core.TheApp.Name())
-		})
-	})
-}
-
-func (ct *Content) MenuSearch(items *[]core.ChooserItem) {
-	newItems := make([]core.ChooserItem, len(ct.pages))
-	for i, pg := range ct.pages {
-		newItems[i] = core.ChooserItem{
-			Value: pg,
-			Text:  pg.Name,
-			Icon:  icons.Article,
-			Func: func() {
-				ct.Open(pg.URL)
-			},
-		}
-	}
-	*items = append(newItems, *items...)
 }

--- a/content/content.go
+++ b/content/content.go
@@ -88,6 +88,10 @@ type Content struct {
 	// currentHeading is the currently selected heading in the table of contents,
 	// if any (in kebab-case).
 	currentHeading string
+
+	// The previous and next page, if applicable. They must be stored on this struct
+	// to avoid stale local closure variables.
+	prevPage, nextPage *bcontent.Page
 }
 
 func init() {
@@ -161,6 +165,7 @@ func (ct *Content) Init() {
 						errors.Log(ct.loadPage(w))
 					})
 				})
+				ct.makeBottomButtons(p)
 			})
 		})
 	})

--- a/core/tree.go
+++ b/core/tree.go
@@ -90,7 +90,10 @@ func AsTree(n tree.Node) *Tree {
 //
 // Standard [events.Event]s are sent to any listeners, including
 // [events.Select], [events.Change], and [events.DoubleClick].
-// The selected nodes are in the root [Tree.SelectedNodes] list.
+// The selected nodes are in the root [Tree.SelectedNodes] list;
+// select events are sent to both selected nodes and the root node.
+// See [Tree.IsRootSelected] to check whether a select event on the root
+// node corresponds to the root node or another node.
 type Tree struct {
 	WidgetBase
 
@@ -669,6 +672,15 @@ func (tr *Tree) RenderWidget() {
 }
 
 ////////  Selection
+
+// IsRootSelected returns whether the root node is the only node selected.
+// This can be used in [events.Select] event handlers to check whether a
+// select event on the root node truly corresponds to the root node or whether
+// it is for another node, as select events are sent to the root when any node
+// is selected.
+func (tr *Tree) IsRootSelected() bool {
+	return len(tr.SelectedNodes) == 1 && tr.SelectedNodes[0] == tr.Root
+}
 
 // GetSelectedNodes returns a slice of the currently selected
 // Trees within the entire tree, using a list maintained

--- a/htmlcore/context.go
+++ b/htmlcore/context.go
@@ -195,11 +195,26 @@ func (c *Context) addStyle(style string) {
 // The advantage of using this is that it does [tree.NodeBase.SetProperty]
 // of "href" to the given url, allowing generatehtml to create an <a> element
 // for HTML preview and SEO purposes.
+//
+// See also [Context.LinkButtonUpdating] for a dynamic version.
 func (c *Context) LinkButton(bt *core.Button, url string) *core.Button {
 	bt.SetProperty("tag", "a")
 	bt.SetProperty("href", url)
 	bt.OnClick(func(e events.Event) {
 		c.OpenURL(url)
+	})
+	return bt
+}
+
+// LinkButtonUpdating is a version of [Context.LinkButton] that is robust to a changing/dynamic
+// URL, using an Updater and a URL function instead of a variable.
+func (c *Context) LinkButtonUpdating(bt *core.Button, url func() string) *core.Button {
+	bt.SetProperty("tag", "a")
+	bt.Updater(func() {
+		bt.SetProperty("href", url())
+	})
+	bt.OnClick(func(e events.Event) {
+		c.OpenURL(url())
 	})
 	return bt
 }


### PR DESCRIPTION
This PR makes it so that all categories are displayed in the tree on the left. It also adds previous and next buttons to the bottom when applicable, and it emphasizes the search button more. It also makes clicking on the root of the contents tree take you to the top of the page, and clicking on the root of the categories tree now takes you to the home page.

Fixes #1472 