### PR TITLE
toHTML: only convert editor to textarea for HTML if it is a textcore.Editor

### DIFF
--- a/core/html.go
+++ b/core/html.go
@@ -46,7 +46,6 @@ var htmlElementNames = map[string]string{
 	"slider":     "input",
 	"meter":      "progress",
 	"chooser":    "select",
-	"editor":     "textarea",
 	"pre":        "textarea",
 	"switches":   "div",
 	"switch":     "input",
@@ -84,6 +83,8 @@ func toHTML(w Widget, e *xml.Encoder, b *bytes.Buffer) error {
 	switch typ.Name {
 	case "cogentcore.org/cogent/canvas.Canvas", "cogentcore.org/cogent/code.Code":
 		se.Name.Local = "div"
+	case "cogentcore.org/core/textcore.Editor":
+		se.Name.Local = "textarea"
 	}
 	if se.Name.Local == "textarea" {
 		wb.Styles.Min.X.Pw(95)


### PR DESCRIPTION
To avoid panics with things like plotcore.Editor.