### PR TITLE
core: fix text field cursor panic by checking if stage is nil

### DIFF
--- a/core/textfield.go
+++ b/core/textfield.go
@@ -1241,7 +1241,7 @@ func (tf *TextField) renderCursor(on bool) {
 		return
 	}
 	if !on {
-		if tf.Scene == nil {
+		if tf.Scene == nil || tf.Scene.Stage == nil {
 			return
 		}
 		ms := tf.Scene.Stage.Main


### PR DESCRIPTION
Fixes #1531 (there is a typo in the commit message for which issue it fixes). 