### PR TITLE
cmd/core: run sudo apt update in core setup

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -26,7 +26,7 @@ jobs:
         go-version: '1.23.4'
 
     - name: Set up Core
-      run: go install ./cmd/core && sudo apt update && core setup
+      run: go install ./cmd/core && core setup
 
     - name: "Install video dependencies (TODO: move to a command)"
       run: sudo add-apt-repository ppa:savoury1/ffmpeg4 && sudo apt install libswscale-dev libavcodec-dev libavformat-dev libswresample-dev libavutil-dev libasound2-dev

--- a/cmd/core/cmd/setup.go
+++ b/cmd/core/cmd/setup.go
@@ -40,6 +40,12 @@ func Setup(c *config.Config) error { //types:add
 			if err != nil {
 				continue // package manager not found
 			}
+			if ld.tool == "apt" { // special case for apt
+				err := vc.Run("sudo", "apt", "update")
+				if err != nil {
+					return err
+				}
+			}
 			cmd, args := ld.cmd()
 			err = vc.Run(cmd, args...)
 			if err != nil {


### PR DESCRIPTION
This fixes CI failures related to packages updating (now you no longer need to manually run `sudo apt update` on CI or locally when running `core setup`).