### PR TITLE
pw: remove intermediate parent-relative sizing calls from layout

### DIFF
--- a/core/layout.go
+++ b/core/layout.go
@@ -650,17 +650,18 @@ func (wb *WidgetBase) updateParentRelSizes() bool {
 		return false
 	}
 	sz := &wb.Geom.Size
+	effmin := sz.Min
 	s := &wb.Styles
 	psz := pwb.Geom.Size.Alloc.Content.Sub(pwb.Geom.Size.InnerSpace)
 	got := false
 	for d := math32.X; d <= math32.Y; d++ {
 		if s.Min.Dim(d).Unit == units.UnitPw {
 			got = true
-			sz.Min.SetDim(d, psz.X*0.01*s.Min.Dim(d).Value)
+			effmin.SetDim(d, psz.X*0.01*s.Min.Dim(d).Value)
 		}
 		if s.Min.Dim(d).Unit == units.UnitPh {
 			got = true
-			sz.Min.SetDim(d, psz.Y*0.01*s.Min.Dim(d).Value)
+			effmin.SetDim(d, psz.Y*0.01*s.Min.Dim(d).Value)
 		}
 		if s.Max.Dim(d).Unit == units.UnitPw {
 			got = true
@@ -672,8 +673,8 @@ func (wb *WidgetBase) updateParentRelSizes() bool {
 		}
 	}
 	if got {
-		sz.FitSizeMax(&sz.Actual.Total, sz.Min)
-		sz.FitSizeMax(&sz.Alloc.Total, sz.Min)
+		sz.FitSizeMax(&sz.Actual.Total, effmin)
+		sz.FitSizeMax(&sz.Alloc.Total, effmin)
 		sz.setContentFromTotal(&sz.Actual)
 		sz.setContentFromTotal(&sz.Alloc)
 	}
@@ -1004,6 +1005,7 @@ func (fr *Frame) sizeFromChildrenStacked() math32.Vector2 {
 // as Actual sizes must always represent the minimums (see Position).
 // Returns true if any change in Actual size occurred.
 func (wb *WidgetBase) SizeDown(iter int) bool {
+	wb.updateParentRelSizes()
 	redo := wb.sizeDownParts(iter)
 	return redo
 }
@@ -1102,6 +1104,7 @@ func (fr *Frame) sizeDownFrame(iter int) bool {
 	if !fr.HasChildren() || !fr.layout.shapeCheck(fr, "SizeDown") {
 		return fr.WidgetBase.SizeDown(iter) // behave like a widget
 	}
+	fr.updateParentRelSizes()
 	sz := &fr.Geom.Size
 	styles.SetClampMaxVector(&sz.Alloc.Content, sz.Max) // can't be more than max..
 	sz.setTotalFromContent(&sz.Alloc)
@@ -1429,6 +1432,7 @@ func (fr *Frame) sizeDownAllocActualStacked(iter int) {
 }
 
 func (fr *Frame) sizeDownCustom(iter int) bool {
+	fr.updateParentRelSizes()
 	fr.growToAlloc()
 	sz := &fr.Geom.Size
 	if DebugSettings.LayoutTrace {
@@ -1551,9 +1555,7 @@ func (wb *WidgetBase) styleSizeUpdate() bool {
 	if pwb == nil {
 		return false
 	}
-	if !wb.updateParentRelSizes() {
-		return false
-	}
+	wb.updateParentRelSizes()
 	scsz := wb.Scene.SceneGeom.Size
 	sz := wb.Geom.Size.Alloc.Content
 	psz := pwb.Geom.Size.Alloc.Content

--- a/core/layout.go
+++ b/core/layout.go
@@ -1004,9 +1004,8 @@ func (fr *Frame) sizeFromChildrenStacked() math32.Vector2 {
 // as Actual sizes must always represent the minimums (see Position).
 // Returns true if any change in Actual size occurred.
 func (wb *WidgetBase) SizeDown(iter int) bool {
-	prel := wb.updateParentRelSizes()
 	redo := wb.sizeDownParts(iter)
-	return prel || redo
+	return redo
 }
 
 func (wb *WidgetBase) sizeDownParts(iter int) bool {
@@ -1103,7 +1102,6 @@ func (fr *Frame) sizeDownFrame(iter int) bool {
 	if !fr.HasChildren() || !fr.layout.shapeCheck(fr, "SizeDown") {
 		return fr.WidgetBase.SizeDown(iter) // behave like a widget
 	}
-	prel := fr.updateParentRelSizes()
 	sz := &fr.Geom.Size
 	styles.SetClampMaxVector(&sz.Alloc.Content, sz.Max) // can't be more than max..
 	sz.setTotalFromContent(&sz.Alloc)
@@ -1120,11 +1118,11 @@ func (fr *Frame) sizeDownFrame(iter int) bool {
 	}
 	fr.This.(Layouter).SizeDownSetAllocs(iter)
 	redo := fr.sizeDownChildren(iter)
-	if prel || redo || wrapped {
+	if redo || wrapped {
 		fr.sizeFromChildrenFit(iter, SizeDownPass)
 	}
 	fr.sizeDownParts(iter) // no std role, just get sizes
-	return chg || wrapped || redo || prel
+	return chg || wrapped || redo
 }
 
 // SizeDownSetAllocs is the key SizeDown step that sets the allocations
@@ -1431,7 +1429,6 @@ func (fr *Frame) sizeDownAllocActualStacked(iter int) {
 }
 
 func (fr *Frame) sizeDownCustom(iter int) bool {
-	prel := fr.updateParentRelSizes()
 	fr.growToAlloc()
 	sz := &fr.Geom.Size
 	if DebugSettings.LayoutTrace {
@@ -1448,7 +1445,7 @@ func (fr *Frame) sizeDownCustom(iter int) bool {
 	})
 	redo := fr.sizeDownChildren(iter)
 	fr.sizeDownParts(iter) // no std role, just get sizes
-	return prel || redo
+	return redo
 }
 
 // sizeFinalUpdateChildrenSizes can optionally be called for layouts
@@ -1548,7 +1545,7 @@ func (fr *Frame) sizeFinalChildren() {
 }
 
 // styleSizeUpdate updates styling size values for widget and its parent,
-// which should be called after these are updated.  Returns true if any changed.
+// which should be called after these are updated. Returns true if any changed.
 func (wb *WidgetBase) styleSizeUpdate() bool {
 	pwb := wb.parentWidget()
 	if pwb == nil {

--- a/core/layout_test.go
+++ b/core/layout_test.go
@@ -236,6 +236,71 @@ func TestParentRelativeSize(t *testing.T) {
 	b.AssertRender(t, "layout/parent-relative")
 }
 
+func TestParentRelativeSizeSplits(t *testing.T) {
+	b := NewBody()
+	b.Styler(func(s *styles.Style) {
+		s.Min.Set(units.Dp(400))
+	})
+
+	splitFrame := NewSplits(b)
+	splitFrame.Styler(func(s *styles.Style) {
+		s.Grow.Set(1, 1)
+		s.Direction = styles.Row
+	})
+	splitFrame.SetSplits(20, 60, 20)
+
+	firstFrame := NewFrame(splitFrame)
+	firstFrame.Styler(func(s *styles.Style) {
+		s.Grow.Set(1, 1)
+		s.Border.Width.Set(units.Dp(4))
+		s.CenterAll()
+	})
+	NewText(firstFrame).SetText("20% Split Frame")
+
+	// The center of the split, created so that we can put child widgets in it
+	centerFrame := NewFrame(splitFrame)
+	centerFrame.Styler(func(s *styles.Style) {
+		s.Direction = styles.Column
+		//s.Overflow.Set(styles.OverflowHidden)
+	})
+
+	// represents a top "menu" bar that has buttons in it
+	centerMenu := NewFrame(centerFrame)
+	centerMenu.Styler(func(s *styles.Style) {
+		s.Min.Set(units.Pw(100), units.Ph(10))
+		s.Max.Set(units.Pw(100), units.Ph(10))
+		s.Border.Width.Set(units.Dp(4))
+		s.CenterAll()
+	})
+	NewText(centerMenu).SetText("Menu Bar")
+
+	// the frame that the child widget will use to wrap its content so that from the outside we only have a single frame
+	centerContentArea := NewFrame(centerFrame)
+	centerContentArea.Styler(func(s *styles.Style) {
+		s.Grow.Set(1, 1)
+		s.Border.Width.Set(units.Dp(4))
+		s.Overflow.Set(styles.OverflowScroll)
+	})
+
+	// represents content that will be too large for this frame, user will need to scroll this on both
+	// axes to interact with it correctly
+	internalCenter := NewFrame(centerContentArea)
+	internalCenter.Styler(func(s *styles.Style) {
+		s.Min.Set(units.Pw(125), units.Ph(125))
+		s.CenterAll()
+	})
+	NewText(internalCenter).SetText("Content in center frame")
+
+	lastFrame := NewFrame(splitFrame)
+	lastFrame.Styler(func(s *styles.Style) {
+		s.Grow.Set(1, 1)
+		s.CenterAll()
+		s.Border.Width.Set(units.Dp(4))
+	})
+	NewText(lastFrame).SetText("20% Split Frame")
+	b.AssertRender(t, "layout/parent-relative-splits")
+}
+
 func TestCustomLayout(t *testing.T) {
 	b := NewBody()
 	b.Styler(func(s *styles.Style) {

--- a/core/layout_test.go
+++ b/core/layout_test.go
@@ -248,7 +248,7 @@ func TestParentRelativeSizeSplits(t *testing.T) {
 		s.Direction = styles.Row
 	})
 	splitFrame.SetSplits(20, 60, 20)
-
+	//
 	firstFrame := NewFrame(splitFrame)
 	firstFrame.Styler(func(s *styles.Style) {
 		s.Grow.Set(1, 1)
@@ -261,6 +261,7 @@ func TestParentRelativeSizeSplits(t *testing.T) {
 	centerFrame := NewFrame(splitFrame)
 	centerFrame.Styler(func(s *styles.Style) {
 		s.Direction = styles.Column
+		s.Grow.Set(1, 1)
 		//s.Overflow.Set(styles.OverflowHidden)
 	})
 
@@ -281,7 +282,7 @@ func TestParentRelativeSizeSplits(t *testing.T) {
 		s.Border.Width.Set(units.Dp(4))
 		s.Overflow.Set(styles.OverflowScroll)
 	})
-
+	//
 	// represents content that will be too large for this frame, user will need to scroll this on both
 	// axes to interact with it correctly
 	internalCenter := NewFrame(centerContentArea)
@@ -290,7 +291,7 @@ func TestParentRelativeSizeSplits(t *testing.T) {
 		s.CenterAll()
 	})
 	NewText(internalCenter).SetText("Content in center frame")
-
+	//
 	lastFrame := NewFrame(splitFrame)
 	lastFrame.Styler(func(s *styles.Style) {
 		s.Grow.Set(1, 1)

--- a/core/text.go
+++ b/core/text.go
@@ -477,6 +477,13 @@ func (tx *Text) SizeDown(iter int) bool {
 	return chg
 }
 
+// todo: could enable this if we see any stragglers
+// func (tx *Text) SizeFinal() {
+// 	tx.WidgetBase.SizeFinal()
+// 	asz := tx.Geom.Size.Actual.Content
+// 	tx.configTextAlloc(asz)
+// }
+
 func (tx *Text) Render() {
 	tx.WidgetBase.Render()
 	tx.Scene.Painter.DrawText(tx.paintText, tx.Geom.Pos.Content)


### PR DESCRIPTION
seems to work. fixes #1516 fixes #1517

to be clear: I tried the example in #1516 and it worked as expected. the inner splitter was always 125%, and there was no outer scrollbar.
