### PR TITLE
focusableInThis: Return first focusable widget, not last

### DIFF
--- a/core/widgetevents.go
+++ b/core/widgetevents.go
@@ -574,6 +574,9 @@ func (wb *WidgetBase) SetFocus() {
 func (wb *WidgetBase) focusableInThis() Widget {
 	var foc Widget
 	wb.WidgetWalkDown(func(cw Widget, cwb *WidgetBase) bool {
+		if foc != nil {
+			return tree.Break
+		}
 		if !cwb.AbilityIs(abilities.Focusable) {
 			return tree.Continue
 		}


### PR DESCRIPTION
WidgetBase.focusableInThis() says it "returns the first Focusable element within this widget". It calls WidgetWalkDown.

WidgetWalkDown calls the given function and stops walking the current branch of the tree if the function returns false. But then it keeps going with other branches of the tree. Which means if there are multiple focusable child widgets, focusableInThis seems to return the last Focusable widget.

Instead, abort the walk if the first focusable widget has been found.

First reported in [Slack](https://gophers.slack.com/archives/C07ENRTB2F7/p1752995199992059).