### PR TITLE
wgpu: update to v25 of wgpu_native libraries

### DIFF
--- a/gpu/buffer.go
+++ b/gpu/buffer.go
@@ -14,8 +14,8 @@ import (
 // note: WriteBuffer is the preferred method for writing, so we only need to manage Read
 
 // BufferMapAsyncError returns an error message if the status is not success.
-func BufferMapAsyncError(status wgpu.BufferMapAsyncStatus) error {
-	if status != wgpu.BufferMapAsyncStatusSuccess {
+func BufferMapAsyncError(status wgpu.MapAsyncStatus) error {
+	if status != wgpu.MapAsyncStatusSuccess {
 		return errors.New("gpu BufferMapAsync was not successful")
 	}
 	return nil
@@ -24,8 +24,8 @@ func BufferMapAsyncError(status wgpu.BufferMapAsyncStatus) error {
 // BufferReadSync does a MapAsync on given buffer, waiting on the device
 // until the sync is complete, and returning error if any issues.
 func BufferReadSync(device *Device, size int, buffer *wgpu.Buffer) error {
-	var status wgpu.BufferMapAsyncStatus
-	err := buffer.MapAsync(wgpu.MapModeRead, 0, uint64(size), func(s wgpu.BufferMapAsyncStatus) {
+	var status wgpu.MapAsyncStatus
+	err := buffer.MapAsync(wgpu.MapModeRead, 0, uint64(size), func(s wgpu.MapAsyncStatus) {
 		status = s
 	})
 	if errors.Log(err) != nil {
@@ -44,9 +44,9 @@ func ValueReadSync(device *Device, values ...*Value) error {
 		return nil
 	}
 	var errs []error
-	status := make([]wgpu.BufferMapAsyncStatus, nv)
+	status := make([]wgpu.MapAsyncStatus, nv)
 	for i, vl := range values {
-		err := vl.readBuffer.MapAsync(wgpu.MapModeRead, 0, uint64(vl.AllocSize), func(s wgpu.BufferMapAsyncStatus) {
+		err := vl.readBuffer.MapAsync(wgpu.MapModeRead, 0, uint64(vl.AllocSize), func(s wgpu.MapAsyncStatus) {
 			status[i] = s
 		})
 		if err != nil {

--- a/gpu/device.go
+++ b/gpu/device.go
@@ -39,8 +39,7 @@ func NewDevice(gpu *GPU) (*Device, error) {
 // It gets the Queue for this device.
 func NewComputeDevice(gpu *GPU) (*Device, error) {
 	// we only request max buffer sizes so compute can go as big as it needs to
-	limits := wgpu.Limits{}
-	limits = wgpu.DefaultLimits()
+	limits := wgpu.DefaultLimits()
 	// Per https://github.com/cogentcore/core/issues/1362 -- this may cause issues on "downlevel"
 	// hardware, so we may need to detect that. OTOH it probably won't be useful for compute anyway,
 	// but we can just sort that out later
@@ -106,5 +105,5 @@ func (dv *Device) WaitDone() {
 	if dv.Device == nil {
 		return
 	}
-	dv.Device.Poll(true, 0)
+	dv.Device.Poll(true, nil)
 }

--- a/gpu/gpipeline.go
+++ b/gpu/gpipeline.go
@@ -185,7 +185,7 @@ func (pl *GraphicsPipeline) Config(rebuild bool) error {
 	if pl.System.Render().Depth.texture != nil {
 		pd.DepthStencil = &wgpu.DepthStencilState{
 			Format:            pl.System.Render().Depth.Format.Format,
-			DepthWriteEnabled: true,
+			DepthWriteEnabled: wgpu.OptionalBoolTrue,
 			DepthCompare:      wgpu.CompareFunctionLess,
 			StencilFront: wgpu.StencilFaceState{
 				Compare: wgpu.CompareFunctionAlways,

--- a/gpu/gpu.go
+++ b/gpu/gpu.go
@@ -88,7 +88,7 @@ type GPU struct {
 	Properties wgpu.AdapterInfo
 
 	// Limits are the limits of the current GPU adapter.
-	Limits wgpu.SupportedLimits
+	Limits wgpu.Limits
 
 	// ComputeOnly indicates if this GPU is only used for compute,
 	// which determines if it listens to GPU_COMPUTE_DEVICE
@@ -181,7 +181,7 @@ func (gp *GPU) init(sf *wgpu.Surface) error {
 		fmt.Println(gp.PropertiesString())
 	}
 
-	gp.MaxComputeWorkGroupCount1D = int(gp.Limits.Limits.MaxComputeWorkgroupsPerDimension)
+	gp.MaxComputeWorkGroupCount1D = int(gp.Limits.MaxComputeWorkgroupsPerDimension)
 	dv := actualVendorName(&gp.Properties)
 	if Debug || DebugAdapter {
 		fmt.Println("GPU device vendor:", dv)
@@ -201,7 +201,7 @@ func (gp *GPU) init(sf *wgpu.Surface) error {
 // string that the adapter VendorName contains,
 // or, failing that, from the description.
 func actualVendorName(ai *wgpu.AdapterInfo) string {
-	nm := strings.ToLower(ai.VendorName)
+	nm := strings.ToLower(ai.Vendor)
 	// source: https://www.reddit.com/r/vulkan/comments/4ta9nj/is_there_a_comprehensive_list_of_the_names_and/
 	switch nm {
 	case "0x10de":
@@ -217,7 +217,7 @@ func actualVendorName(ai *wgpu.AdapterInfo) string {
 	case "0x8086":
 		return "intel"
 	}
-	vd := strings.ToLower(ai.DriverDescription)
+	vd := strings.ToLower(ai.Description)
 	if strings.Contains(vd, "apple") {
 		return "apple"
 	}
@@ -225,13 +225,13 @@ func actualVendorName(ai *wgpu.AdapterInfo) string {
 }
 
 func adapterName(ai *wgpu.AdapterInfo) string {
-	if ai.Name != "" && !strings.HasPrefix(ai.Name, "0x") {
-		return ai.Name
+	if ai.Device != "" && !strings.HasPrefix(ai.Device, "0x") {
+		return ai.Device
 	}
-	if ai.DriverDescription != "" && !strings.HasPrefix(ai.DriverDescription, "0x") {
-		return ai.DriverDescription
+	if ai.Description != "" && !strings.HasPrefix(ai.Description, "0x") {
+		return ai.Description
 	}
-	return ai.VendorName
+	return ai.Vendor
 }
 
 func (gp *GPU) SelectGraphicsGPU(gpus []*wgpu.Adapter) int {
@@ -259,7 +259,7 @@ func (gp *GPU) SelectGraphicsGPU(gpus []*wgpu.Adapter) int {
 			}
 			pnm := adapterName(&props)
 			if strings.Contains(pnm, trgDevNm) {
-				devNm := props.Name
+				devNm := props.Device
 				if Debug {
 					log.Printf("gpu: selected device named: %s, specified in GPU_DEVICE or GPU_COMPUTE_DEVICE environment variable, index: %d\n", devNm, gi)
 				}
@@ -349,7 +349,7 @@ func (gp *GPU) SelectComputeGPU(gpus []*wgpu.Adapter) int {
 			}
 			pnm := adapterName(&props)
 			if strings.Contains(pnm, trgDevNm) {
-				devNm := props.Name
+				devNm := props.Device
 				if Debug {
 					log.Printf("gpu: selected device named: %s, specified in GPU_DEVICE or GPU_COMPUTE_DEVICE environment variable, index: %d\n", devNm, gi)
 				}
@@ -408,7 +408,7 @@ func (gp *GPU) NewDevice() (*Device, error) {
 
 // PropertiesString returns a human-readable summary of the GPU properties.
 func (gp *GPU) PropertiesString() string {
-	return "\n######## GPU Properties\n" + reflectx.StringJSON(&gp.Properties) + reflectx.StringJSON(gp.Limits.Limits)
+	return "\n######## GPU Properties\n" + reflectx.StringJSON(&gp.Properties) + reflectx.StringJSON(gp.Limits)
 }
 
 // NoDisplayGPU Initializes WebGPU and returns that and a new

--- a/gpu/shader.go
+++ b/gpu/shader.go
@@ -57,8 +57,8 @@ func (sh *Shader) OpenFileFS(fsys fs.FS, fname string) error {
 // OpenCode loads given WGSL ".wgl" code for the Shader.
 func (sh *Shader) OpenCode(code string) error {
 	module, err := sh.device.Device.CreateShaderModule(&wgpu.ShaderModuleDescriptor{
-		Label:          sh.Name,
-		WGSLDescriptor: &wgpu.ShaderModuleWGSLDescriptor{Code: code},
+		Label:      sh.Name,
+		WGSLSource: &wgpu.ShaderSourceWGSL{Code: code},
 	})
 	if errors.Log(err) != nil {
 		return err

--- a/gpu/texture.go
+++ b/gpu/texture.go
@@ -93,14 +93,14 @@ func (tx *Texture) SetFromGoImage(img image.Image, layer int) error {
 
 	// https://www.w3.org/TR/webgpu/#gpuimagecopytexture
 	tx.device.Queue.WriteTexture(
-		&wgpu.ImageCopyTexture{
+		&wgpu.TexelCopyTextureInfo{
 			Aspect:   wgpu.TextureAspectAll,
 			Texture:  tx.texture,
 			MipLevel: 0,
 			Origin:   wgpu.Origin3D{X: 0, Y: 0, Z: 0},
 		},
 		rimg.Pix,
-		&wgpu.TextureDataLayout{
+		&wgpu.TexelCopyBufferLayout{
 			Offset:       0,
 			BytesPerRow:  4 * uint32(sz.X),
 			RowsPerImage: uint32(sz.Y),
@@ -259,9 +259,9 @@ func (tx *Texture) CopyToReadBuffer(cmd *wgpu.CommandEncoder) error {
 	size := tx.Format.Extent3D()
 	cmd.CopyTextureToBuffer(
 		tx.texture.AsImageCopy(),
-		&wgpu.ImageCopyBuffer{
+		&wgpu.TexelCopyBufferInfo{
 			Buffer: tx.readBuffer,
-			Layout: wgpu.TextureDataLayout{
+			Layout: wgpu.TexelCopyBufferLayout{
 				Offset:       0,
 				BytesPerRow:  uint32(tx.ReadBufferDims.PaddedRowSize),
 				RowsPerImage: wgpu.CopyStrideUndefined,

--- a/gpu/types.go
+++ b/gpu/types.go
@@ -139,7 +139,7 @@ var TypeSizes = map[Types]int{
 
 // TypeToVertexFormat maps gpu.Types to WebGPU VertexFormat
 var TypeToVertexFormat = map[Types]wgpu.VertexFormat{
-	UndefinedType: wgpu.VertexFormatUndefined,
+	UndefinedType: 0,
 	// Bool32:         wgpu.VertexFormatUint32,
 	// Int16:          wgpu.VertexFormatR16Sint,
 	// Uint16:         wgpu.VertexFormatR16Uint,

--- a/gpu/vars.go
+++ b/gpu/vars.go
@@ -101,12 +101,12 @@ func (vs *Vars) AddGroup(role VarRoles, name ...string) *VarGroup {
 	}
 	vg.alignBytes = 1
 	if role == Uniform {
-		vg.alignBytes = int(vs.sys.GPU().Limits.Limits.MinUniformBufferOffsetAlignment)
+		vg.alignBytes = int(vs.sys.GPU().Limits.MinUniformBufferOffsetAlignment)
 		// note: wgpu-native reports alignment sizes of 64
 		// but then barfs when that is used.  256 seems to keep it happy
 		vg.alignBytes = max(vg.alignBytes, 256)
 	} else if role == Storage {
-		vg.alignBytes = int(vs.sys.GPU().Limits.Limits.MinStorageBufferOffsetAlignment)
+		vg.alignBytes = int(vs.sys.GPU().Limits.MinStorageBufferOffsetAlignment)
 		vg.alignBytes = max(vg.alignBytes, 256)
 	}
 	vs.Groups[idx] = vg

--- a/htmlcore/handler.go
+++ b/htmlcore/handler.go
@@ -17,7 +17,9 @@ import (
 	"cogentcore.org/core/base/iox/imagex"
 	"cogentcore.org/core/colors"
 	"cogentcore.org/core/core"
+	"cogentcore.org/core/events"
 	"cogentcore.org/core/styles"
+	"cogentcore.org/core/styles/abilities"
 	"cogentcore.org/core/styles/states"
 	"cogentcore.org/core/styles/units"
 	"cogentcore.org/core/text/lines"
@@ -272,6 +274,15 @@ func handleElement(ctx *Context) {
 			if pid != "" {
 				img.SetName(pid)
 			}
+			img.Styler(func(s *styles.Style) {
+				s.SetAbilities(true, abilities.Clickable, abilities.DoubleClickable)
+				s.Overflow.Set(styles.OverflowAuto)
+			})
+			img.OnDoubleClick(func(e events.Event) {
+				d := core.NewBody("Image")
+				core.NewImage(d).SetImage(img.Image)
+				d.RunWindowDialog(img)
+			})
 		}
 
 		go func() {


### PR DESCRIPTION
This updates core/gpu to the API changes in https://github.com/cogentcore/webgpu/pull/8 -- it won't work until that is merged and the libraries are updated and committed.  It can be used until then by following the directions on that PR.
