### PR TITLE
cursorcache: fixes #1625

### DIFF
--- a/cursors/cursorimg/cursorimg.go
+++ b/cursors/cursorimg/cursorimg.go
@@ -81,9 +81,11 @@ func Get(cursor enums.Enum, size int) (*Cursor, error) {
 	shadow = pimage.GaussianBlur(shadow, float64(blurRadius))
 	draw.Draw(shadow, shadow.Bounds(), img, image.Point{}, draw.Over)
 
-	return &Cursor{
+	c := &Cursor{
 		Image:   shadow,
 		Size:    size,
 		Hotspot: hot.Mul(size).Div(256),
-	}, nil
+	}
+	sm[size] = c
+	return c, nil
 }


### PR DESCRIPTION
fixes #1625 -- except that it was actually being cached at a higher level so it wasn't such a big deal, but anyway this makes the lower cache actually functional. confirmed that fixing this doesn't break dark / light mode switching.
