### PR TITLE
Content fixes: ctrl+click for new tab, and fix the history

### DIFF
--- a/content/buttons.go
+++ b/content/buttons.go
@@ -38,7 +38,7 @@ func (ct *Content) MakeToolbar(p *tree.Plan) {
 		w.SetIcon(icons.Icon(core.AppIcon))
 		w.SetTooltip("Home")
 		w.OnClick(func(e events.Event) {
-			ct.Open("")
+			ct.OpenEvent("", e)
 		})
 	})
 	// Superseded by browser navigation on web.

--- a/content/buttons.go
+++ b/content/buttons.go
@@ -47,22 +47,20 @@ func (ct *Content) MakeToolbar(p *tree.Plan) {
 			w.SetIcon(icons.ArrowBack).SetKey(keymap.HistPrev)
 			w.SetTooltip("Back")
 			w.Updater(func() {
-				w.SetEnabled(ct.historyIndex > 0)
+				w.SetEnabled(ct.historyHasBack())
 			})
 			w.OnClick(func(e events.Event) {
-				ct.historyIndex--
-				ct.open(ct.history[ct.historyIndex].URL, false) // do not add to history while navigating history
+				ct.historyBack()
 			})
 		})
 		tree.Add(p, func(w *core.Button) {
 			w.SetIcon(icons.ArrowForward).SetKey(keymap.HistNext)
 			w.SetTooltip("Forward")
 			w.Updater(func() {
-				w.SetEnabled(ct.historyIndex < len(ct.history)-1)
+				w.SetEnabled(ct.historyHasForward())
 			})
 			w.OnClick(func(e events.Event) {
-				ct.historyIndex++
-				ct.open(ct.history[ct.historyIndex].URL, false) // do not add to history while navigating history
+				ct.historyForward()
 			})
 		})
 	}

--- a/content/buttons.go
+++ b/content/buttons.go
@@ -78,7 +78,7 @@ func (ct *Content) MakeToolbar(p *tree.Plan) {
 			s.Padding.Right.Em(5)
 		})
 		w.OnClick(func(e events.Event) {
-			ct.Scene.MenuSearchDialog("Search", "Search "+core.TheApp.Name())
+			core.TextSearch(ct, "", true)
 		})
 	})
 }

--- a/content/buttons.go
+++ b/content/buttons.go
@@ -103,12 +103,12 @@ func (ct *Content) MenuSearch(items *[]core.ChooserItem) {
 
 // makeBottomButtons makes the previous and next buttons if relevant.
 func (ct *Content) makeBottomButtons(p *tree.Plan) {
-	if len(ct.currentPage.Categories) == 0 {
+	if len(ct.current.Page.Categories) == 0 {
 		return
 	}
-	cat := ct.currentPage.Categories[0]
+	cat := ct.current.Page.Categories[0]
 	pages := ct.pagesByCategory[cat]
-	idx := slices.Index(pages, ct.currentPage)
+	idx := slices.Index(pages, ct.current.Page)
 
 	ct.prevPage, ct.nextPage = nil, nil
 

--- a/content/buttons.go
+++ b/content/buttons.go
@@ -78,7 +78,7 @@ func (ct *Content) MakeToolbar(p *tree.Plan) {
 			s.Padding.Right.Em(5)
 		})
 		w.OnClick(func(e events.Event) {
-			core.TextSearch(ct, "", true)
+			core.TextSearch(ct, core.LastTextSearch, core.LastUseCase)
 		})
 	})
 }

--- a/content/buttons.go
+++ b/content/buttons.go
@@ -72,7 +72,8 @@ func (ct *Content) MakeToolbar(p *tree.Plan) {
 		})
 	}
 	tree.Add(p, func(w *core.Button) {
-		w.SetText("Page Search").SetIcon(icons.Search).SetKey(keymap.Menu)
+		w.SetText("Page Search").SetIcon(icons.Search).SetKey(keymap.Menu).
+			SetTooltip("Search for pages by name")
 		w.Styler(func(s *styles.Style) {
 			s.Background = colors.Scheme.SurfaceVariant
 			s.Padding.Right.Em(5)
@@ -82,13 +83,15 @@ func (ct *Content) MakeToolbar(p *tree.Plan) {
 		})
 	})
 	tree.Add(p, func(w *core.Button) {
-		w.SetText("Search").SetIcon(icons.Search).SetKey(keymap.Menu)
+		w.SetText("Search").SetIcon(icons.Search).SetKey(keymap.Find).
+			SetTooltip("Search within content of current page")
 		w.Styler(func(s *styles.Style) {
 			s.Background = colors.Scheme.SurfaceVariant
 			s.Padding.Right.Em(5)
 		})
 		w.OnClick(func(e events.Event) {
-			core.Search(ct, core.LastSearch, core.LastUseCase)
+			e.SetHandled()
+			core.Search(ct.rightFrame, core.LastSearch, core.LastUseCase)
 		})
 	})
 }

--- a/content/buttons.go
+++ b/content/buttons.go
@@ -78,7 +78,7 @@ func (ct *Content) MakeToolbar(p *tree.Plan) {
 			s.Padding.Right.Em(5)
 		})
 		w.OnClick(func(e events.Event) {
-			core.TextSearch(ct, core.LastTextSearch, core.LastUseCase)
+			core.Search(ct, core.LastSearch, core.LastUseCase)
 		})
 	})
 }

--- a/content/buttons.go
+++ b/content/buttons.go
@@ -44,6 +44,7 @@ func (ct *Content) MakeToolbar(p *tree.Plan) {
 	// Superseded by browser navigation on web.
 	if core.TheApp.Platform() != system.Web {
 		tree.Add(p, func(w *core.Button) {
+			ct.toolbar = w.Parent.(*core.Toolbar)
 			w.SetIcon(icons.ArrowBack).SetKey(keymap.HistPrev)
 			w.SetTooltip("Back")
 			w.Updater(func() {
@@ -51,6 +52,9 @@ func (ct *Content) MakeToolbar(p *tree.Plan) {
 			})
 			w.OnClick(func(e events.Event) {
 				ct.historyBack()
+				if ct.toolbar != nil {
+					ct.toolbar.Update()
+				}
 			})
 		})
 		tree.Add(p, func(w *core.Button) {
@@ -61,6 +65,9 @@ func (ct *Content) MakeToolbar(p *tree.Plan) {
 			})
 			w.OnClick(func(e events.Event) {
 				ct.historyForward()
+				if ct.toolbar != nil {
+					ct.toolbar.Update()
+				}
 			})
 		})
 	}

--- a/content/buttons.go
+++ b/content/buttons.go
@@ -73,14 +73,14 @@ func (ct *Content) MakeToolbar(p *tree.Plan) {
 	}
 	tree.Add(p, func(w *core.Button) {
 		find := keymap.Find.Chord().Label()
-		w.SetText("Page Search").SetIcon(icons.Search).SetKey(keymap.Menu).
+		w.SetText("Search").SetIcon(icons.Search).SetKey(keymap.Menu).
 			SetTooltip("Search for pages by name (use " + find + " or context menu to search within current page)")
 		w.Styler(func(s *styles.Style) {
 			s.Background = colors.Scheme.SurfaceVariant
 			s.Padding.Right.Em(5)
 		})
 		w.OnClick(func(e events.Event) {
-			ct.Scene.MenuSearchDialog("Page Search", "Page Search "+core.TheApp.Name())
+			ct.Scene.MenuSearchDialog("Page search", "Search "+core.TheApp.Name())
 		})
 	})
 }

--- a/content/buttons.go
+++ b/content/buttons.go
@@ -72,6 +72,16 @@ func (ct *Content) MakeToolbar(p *tree.Plan) {
 		})
 	}
 	tree.Add(p, func(w *core.Button) {
+		w.SetText("Page Search").SetIcon(icons.Search).SetKey(keymap.Menu)
+		w.Styler(func(s *styles.Style) {
+			s.Background = colors.Scheme.SurfaceVariant
+			s.Padding.Right.Em(5)
+		})
+		w.OnClick(func(e events.Event) {
+			ct.Scene.MenuSearchDialog("Page Search", "Page Search "+core.TheApp.Name())
+		})
+	})
+	tree.Add(p, func(w *core.Button) {
 		w.SetText("Search").SetIcon(icons.Search).SetKey(keymap.Menu)
 		w.Styler(func(s *styles.Style) {
 			s.Background = colors.Scheme.SurfaceVariant

--- a/content/buttons.go
+++ b/content/buttons.go
@@ -72,26 +72,15 @@ func (ct *Content) MakeToolbar(p *tree.Plan) {
 		})
 	}
 	tree.Add(p, func(w *core.Button) {
+		find := keymap.Find.Chord().Label()
 		w.SetText("Page Search").SetIcon(icons.Search).SetKey(keymap.Menu).
-			SetTooltip("Search for pages by name")
+			SetTooltip("Search for pages by name (use " + find + " or context menu to search within current page)")
 		w.Styler(func(s *styles.Style) {
 			s.Background = colors.Scheme.SurfaceVariant
 			s.Padding.Right.Em(5)
 		})
 		w.OnClick(func(e events.Event) {
 			ct.Scene.MenuSearchDialog("Page Search", "Page Search "+core.TheApp.Name())
-		})
-	})
-	tree.Add(p, func(w *core.Button) {
-		w.SetText("Search").SetIcon(icons.Search).SetKey(keymap.Find).
-			SetTooltip("Search within content of current page")
-		w.Styler(func(s *styles.Style) {
-			s.Background = colors.Scheme.SurfaceVariant
-			s.Padding.Right.Em(5)
-		})
-		w.OnClick(func(e events.Event) {
-			e.SetHandled()
-			core.Search(ct.rightFrame, core.LastSearch, core.LastUseCase)
 		})
 	})
 }
@@ -102,6 +91,23 @@ func (ct *Content) MakeToolbarPDF(p *tree.Plan) {
 		w.SetText("PDF").SetIcon(icons.PictureAsPdf).SetTooltip("PDF generates and opens / downloads the current page as a printable PDF file. See the Settings/Printer panel (Command+,) for settings.")
 		w.OnClick(func(e events.Event) {
 			ct.PagePDF("pdfs")
+		})
+	})
+}
+
+// MakeToolbarSearch adds a within-page search button to the toolbar.
+// This is optional.
+func (ct *Content) MakeToolbarSearch(p *tree.Plan) {
+	tree.Add(p, func(w *core.Button) {
+		w.SetText("Search").SetIcon(icons.Search).SetKey(keymap.Find).
+			SetTooltip("Search within content of current page")
+		w.Styler(func(s *styles.Style) {
+			s.Background = colors.Scheme.SurfaceVariant
+			s.Padding.Right.Em(5)
+		})
+		w.OnClick(func(e events.Event) {
+			e.SetHandled()
+			core.Search(ct.rightFrame, core.LastSearch, core.LastUseCase)
 		})
 	})
 }

--- a/content/content.go
+++ b/content/content.go
@@ -155,7 +155,7 @@ func (ct *Content) Init() {
 		tree.Add(p, func(w *core.Frame) {
 			ct.rightFrame = w
 			w.Maker(func(p *tree.Plan) {
-				if core.TheApp.Platform() == system.Web {
+				if core.TheApp.Platform() == system.Web || core.GenerateHTML != nil {
 					ct.pageMaker(p, 0)
 				} else {
 					tree.Add(p, func(w *core.Tabs) {

--- a/content/content.go
+++ b/content/content.go
@@ -380,11 +380,11 @@ func (ct *Content) OpenEvent(url string, e events.Event) *Content {
 		core.TheApp.OpenURL(nw.String())
 		return ct
 	}
-	ct.newTab(ct.tabs.NewTab("nt"))
+	nt := ct.tabs.NumTabs()
+	nm := fmt.Sprintf("Tab %d", nt+1)
+	ct.newTab(ct.tabs.NewTab(nm))
 	return ct.Open(url)
 }
-
-// todo: also need tab delete!
 
 func (ct *Content) newTab(fr *core.Frame, tb *core.Tab) {
 	ct.rendered.Reset()
@@ -452,7 +452,7 @@ func (ct *Content) makeTableOfContents(w *core.Frame, pg *bcontent.Page) {
 		if contents.IsRootSelected() {
 			ct.pageFrame().ScrollDimToContentStart(math32.Y)
 			ct.current.Heading = ""
-			ct.saveWebURL()
+			ct.saveWebURL(&ct.current)
 		}
 	})
 	// last is the most recent tree node for each heading level, used for nesting.
@@ -481,7 +481,7 @@ func (ct *Content) makeTableOfContents(w *core.Frame, pg *bcontent.Page) {
 			ct.tocNodes[kebab] = tr
 			tr.OnSelect(func(e events.Event) {
 				tx.ScrollThisToTop()
-				ct.open(ct.current.Page.URL+"#"+kebab, true)
+				ct.OpenEvent(ct.current.Page.URL+"#"+kebab, e)
 			})
 		}
 		return tree.Continue
@@ -502,7 +502,7 @@ func (ct *Content) makeCategories() {
 	cats.SetReadOnly(true)
 	cats.OnSelect(func(e events.Event) {
 		if cats.IsRootSelected() {
-			ct.Open("")
+			ct.OpenEvent("", e)
 		}
 	})
 	for _, cat := range ct.categories {
@@ -512,7 +512,7 @@ func (ct *Content) makeCategories() {
 		}
 		catTree.OnSelect(func(e events.Event) {
 			if catPage := ct.pageByName(cat); catPage != nil {
-				ct.Open(catPage.URL)
+				ct.OpenEvent(catPage.URL, e)
 			} else {
 				catTree.Open() // no page to open so open the tree
 			}
@@ -527,7 +527,7 @@ func (ct *Content) makeCategories() {
 				catTree.SetClosed(false)
 			}
 			pgTree.OnSelect(func(e events.Event) {
-				ct.Open(pg.URL)
+				ct.OpenEvent(pg.URL, e)
 			})
 		}
 	}

--- a/content/content.go
+++ b/content/content.go
@@ -389,8 +389,7 @@ func (ct *Content) reloadPage() {
 // loadPage loads the current page content into the given frame if it is not already loaded.
 func (ct *Content) loadPage(w *core.Frame) error {
 	if ct.rendered == ct.current { // this prevents tabs from rendering
-		fmt.Println("rerender")
-		// todo: bail
+		return nil
 	}
 	if NewPageInitFunc != nil {
 		NewPageInitFunc()

--- a/content/content.go
+++ b/content/content.go
@@ -157,6 +157,7 @@ func (ct *Content) Init() {
 				} else {
 					tree.Add(p, func(w *core.Tabs) {
 						ct.tabs = w
+						w.SetType(core.FunctionalTabs).SetNewTabButton(true)
 						tb, _ := w.NewTab("Content")
 						h := &History{}
 						h.Save(ct.current.Page, ct.current.Heading, ct.current.Page.URL) // todo: URL not quite right

--- a/content/examples/basic/content/button.md
+++ b/content/examples/basic/content/button.md
@@ -100,6 +100,12 @@ Action and menu buttons are the most minimal buttons, and they are typically onl
 core.NewButton(b).SetType(core.ButtonAction).SetText("Action")
 ```
 
+> This is the first quote
+
+> And this is the second quote
+
+> and this is the last quote
+
 ### Third level header
 
 This is content at the third level.

--- a/content/handlers.go
+++ b/content/handlers.go
@@ -385,7 +385,7 @@ func (ct *Content) open(url string, history bool) {
 	}
 	ct.currentPage = pg
 	if history {
-		ct.addHistory(pg)
+		ct.historyAdd(pg, heading, url)
 	}
 	ct.Scene.Update() // need to update the whole scene to also update the toolbar
 	// We can only scroll to the heading after the page layout has been updated, so we defer.
@@ -404,7 +404,7 @@ func (ct *Content) openRef(url string) {
 	}
 	ref := strings.TrimPrefix(url, "ref://")
 	ct.currentPage = pg
-	ct.addHistory(pg)
+	ct.historyAdd(pg, "", url)
 	ct.Scene.Update()
 	ct.Defer(func() {
 		ct.setStageTitle()
@@ -414,7 +414,7 @@ func (ct *Content) openRef(url string) {
 
 func (ct *Content) openHeading(heading string) {
 	if heading == "" {
-		ct.rightFrame.ScrollDimToContentStart(math32.Y)
+		ct.pageFrame().ScrollDimToContentStart(math32.Y)
 		return
 	}
 	idname := "" // in case of #id:element
@@ -445,11 +445,11 @@ func (ct *Content) openHeading(heading string) {
 
 func (ct *Content) openID(id, element string) bool {
 	if id == "" {
-		ct.rightFrame.ScrollDimToContentStart(math32.Y)
+		ct.pageFrame().ScrollDimToContentStart(math32.Y)
 		return true
 	}
 	var found *core.WidgetBase
-	ct.rightFrame.WidgetWalkDown(func(cw core.Widget, cwb *core.WidgetBase) bool {
+	ct.pageFrame().WidgetWalkDown(func(cw core.Widget, cwb *core.WidgetBase) bool {
 		// if found != nil {
 		// 	return tree.Break
 		// }

--- a/content/handlers.go
+++ b/content/handlers.go
@@ -442,6 +442,8 @@ func (ct *Content) openHeading(heading string) {
 		}
 		return
 	}
+	tr.UnselectAll()
+	tr.Select()
 	tx := tr.Property("page-text").(*core.Text)
 	tx.ScrollThisToTop()
 }

--- a/content/handlers.go
+++ b/content/handlers.go
@@ -343,20 +343,11 @@ func (ct *Content) wikilinkLabel(pg *bcontent.Page, heading string) string {
 	return label
 }
 
-// open opens the page with the given URL and updates the display.
-// It optionally adds the page to the history.
-func (ct *Content) open(url string, history bool) {
-	if strings.HasPrefix(url, "https://") || strings.HasPrefix(url, "http://") {
-		core.TheApp.OpenURL(url)
-		return
-	}
-	if strings.HasPrefix(url, "ref://") {
-		ct.openRef(url)
-		return
-	}
+// parseURL parses the given local url into a page and heading.
+func (ct *Content) parseURL(url string) (pgUrl string, pg *bcontent.Page, heading string) {
 	url = strings.ReplaceAll(url, "/#", "#")
-	url, heading, _ := strings.Cut(url, "#")
-	pg := ct.pagesByURL[url]
+	pgUrl, heading, _ = strings.Cut(url, "#")
+	pg = ct.pagesByURL[url]
 	if pg == nil {
 		// We want only the URL after the last slash for automatic redirects
 		// (old URLs could have nesting).
@@ -372,6 +363,21 @@ func (ct *Content) open(url string, history bool) {
 		}
 	}
 	heading = bcontent.SpecialToKebab(heading)
+	return
+}
+
+// open opens the page with the given URL and updates the display.
+// It optionally adds the page to the history.
+func (ct *Content) open(url string, history bool) {
+	if strings.HasPrefix(url, "https://") || strings.HasPrefix(url, "http://") {
+		core.TheApp.OpenURL(url)
+		return
+	}
+	if strings.HasPrefix(url, "ref://") {
+		ct.openRef(url)
+		return
+	}
+	url, pg, heading := ct.parseURL(url)
 	ct.currentHeading = heading
 	if ct.currentPage == pg {
 		ct.openHeading(heading)

--- a/content/history.go
+++ b/content/history.go
@@ -5,6 +5,8 @@
 package content
 
 import (
+	"fmt"
+
 	"cogentcore.org/core/content/bcontent"
 )
 
@@ -32,7 +34,6 @@ func (ct *Content) historyBack() {
 	}
 	_, ci := ct.tabs.CurrentTab()
 	lc, _ := ct.history[ci].Back()
-	// fmt.Println("back:", lc.URL)
 	ct.open(lc.URL, false) // no add more history
 }
 
@@ -69,11 +70,24 @@ func (lc *Location) Reset() {
 	lc.URL = ""
 }
 
+func (lc *Location) String() string {
+	if lc.Page != nil {
+		return fmt.Sprintf("%q (page: %q head: %q)", lc.URL, lc.Page.URL, lc.Heading)
+	}
+	return fmt.Sprintf("%q", lc.URL)
+}
+
+func (lc *Location) Clone() *Location {
+	nc := &Location{}
+	*nc = *lc
+	return nc
+}
+
 // History records the history of browsing locations, for back arrow
 // navigation.
 type History struct {
-	// Index is the current index in the Records.
-	// This is the location to use when the back arrow happens.
+	// Index is the current index in the Records, which is typically the
+	// current page as saved. Back decrements then returns that.
 	Index int
 
 	// Records is the list of saved locations.
@@ -97,7 +111,7 @@ func (hs *History) Save(lc *Location) {
 	}
 }
 
-// Back returns current back location and decrements Index.
+// Back decrements Index and returns that location.
 // If already at the start, returns false.
 func (hs *History) Back() (*Location, bool) {
 	if hs.Index <= 0 {

--- a/content/history.go
+++ b/content/history.go
@@ -1,0 +1,114 @@
+// Copyright (c) 2026, Cogent Core. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package content
+
+import "cogentcore.org/core/content/bcontent"
+
+func (ct *Content) historyAdd(pg *bcontent.Page, header, url string) {
+	if ct.tabs == nil {
+		ct.saveWebURL()
+		return
+	}
+	_, ci := ct.tabs.CurrentTab()
+	ct.history[ci].Save(pg, header, url)
+}
+
+func (ct *Content) historyHasBack() bool {
+	if ct.tabs == nil { // shouldn't happen
+		return false
+	}
+	_, ci := ct.tabs.CurrentTab()
+	h := ct.history[ci]
+	return h.Index > 0
+}
+
+func (ct *Content) historyBack() {
+	if ct.tabs == nil { // shouldn't happen
+		return
+	}
+	_, ci := ct.tabs.CurrentTab()
+	lc, _ := ct.history[ci].Back()
+	ct.open(lc.URL, false) // no add more history
+}
+
+func (ct *Content) historyHasForward() bool {
+	if ct.tabs == nil { // shouldn't happen
+		return false
+	}
+	_, ci := ct.tabs.CurrentTab()
+	h := ct.history[ci]
+	return h.Index < len(h.Records)-1
+}
+
+func (ct *Content) historyForward() {
+	if ct.tabs == nil { // shouldn't happen
+		return
+	}
+	_, ci := ct.tabs.CurrentTab()
+	lc, _ := ct.history[ci].Forward()
+	ct.open(lc.URL, false) // no add more history
+}
+
+///////// History
+
+// Location holds one location of browsing history.
+type Location struct {
+	Page    *bcontent.Page
+	Heading string
+	URL     string
+}
+
+// History records the history of browsing locations, for back arrow
+// navigation.
+type History struct {
+	// Index is the current index in the Records.
+	// This is the location to use when the back arrow happens.
+	Index int
+
+	// Records is the list of saved locations.
+	Records []*Location
+}
+
+func (hs *History) Save(pg *bcontent.Page, heading, url string) {
+	lc := &Location{Page: pg, Heading: heading, URL: url}
+	if hs.Records == nil {
+		hs.Records = make([]*Location, 1)
+		hs.Index = 0
+		hs.Records[0] = lc
+		return
+	}
+	hs.Index++
+	if len(hs.Records) > hs.Index {
+		hs.Records = hs.Records[:hs.Index+1]
+		hs.Records[hs.Index] = lc
+	} else {
+		hs.Index = len(hs.Records) // note: going to end first
+		hs.Records = append(hs.Records, lc)
+	}
+}
+
+// Back returns current back location and decrements Index.
+// If already at the start, returns false.
+func (hs *History) Back() (*Location, bool) {
+	if hs.Index <= 0 {
+		return hs.Records[0], false
+	}
+	if hs.Index == len(hs.Records)-1 { // top one is always current.
+		hs.Index--
+	}
+	lc := hs.Records[hs.Index]
+	hs.Index--
+	return lc, true
+}
+
+// Forward returns next location and increments Index.
+// returns false if already at end (returns end location).
+func (hs *History) Forward() (*Location, bool) {
+	if hs.Index == len(hs.Records)-1 {
+		return hs.Records[hs.Index], false
+	}
+	hs.Index++
+	return hs.Records[hs.Index], true
+}

--- a/content/history.go
+++ b/content/history.go
@@ -8,13 +8,13 @@ import (
 	"cogentcore.org/core/content/bcontent"
 )
 
-func (ct *Content) historyAdd(pg *bcontent.Page, header, url string) {
+func (ct *Content) historyAdd(pg *bcontent.Page, heading, url string) {
 	if ct.tabs == nil {
 		ct.saveWebURL()
 		return
 	}
 	_, ci := ct.tabs.CurrentTab()
-	ct.history[ci].Save(pg, header, url)
+	ct.history[ci].Save(&Location{Page: pg, Heading: heading, URL: url})
 }
 
 func (ct *Content) historyHasBack() bool {
@@ -32,6 +32,7 @@ func (ct *Content) historyBack() {
 	}
 	_, ci := ct.tabs.CurrentTab()
 	lc, _ := ct.history[ci].Back()
+	// fmt.Println("back:", lc.URL)
 	ct.open(lc.URL, false) // no add more history
 }
 
@@ -79,8 +80,7 @@ type History struct {
 	Records []*Location
 }
 
-func (hs *History) Save(pg *bcontent.Page, heading, url string) {
-	lc := &Location{Page: pg, Heading: heading, URL: url}
+func (hs *History) Save(lc *Location) {
 	if hs.Records == nil {
 		hs.Records = make([]*Location, 1)
 		hs.Index = 0

--- a/content/history.go
+++ b/content/history.go
@@ -12,7 +12,7 @@ import (
 
 func (ct *Content) historyAdd(pg *bcontent.Page, heading, url string) {
 	if ct.tabs == nil {
-		ct.saveWebURL()
+		ct.saveWebURL(&Location{Page: pg, Heading: heading, URL: url})
 		return
 	}
 	_, ci := ct.tabs.CurrentTab()

--- a/content/history.go
+++ b/content/history.go
@@ -4,7 +4,9 @@
 
 package content
 
-import "cogentcore.org/core/content/bcontent"
+import (
+	"cogentcore.org/core/content/bcontent"
+)
 
 func (ct *Content) historyAdd(pg *bcontent.Page, header, url string) {
 	if ct.tabs == nil {
@@ -60,6 +62,12 @@ type Location struct {
 	URL     string
 }
 
+func (lc *Location) Reset() {
+	lc.Page = nil
+	lc.Heading = ""
+	lc.URL = ""
+}
+
 // History records the history of browsing locations, for back arrow
 // navigation.
 type History struct {
@@ -95,11 +103,8 @@ func (hs *History) Back() (*Location, bool) {
 	if hs.Index <= 0 {
 		return hs.Records[0], false
 	}
-	if hs.Index == len(hs.Records)-1 { // top one is always current.
-		hs.Index--
-	}
-	lc := hs.Records[hs.Index]
 	hs.Index--
+	lc := hs.Records[hs.Index]
 	return lc, true
 }
 

--- a/content/url_js.go
+++ b/content/url_js.go
@@ -12,6 +12,7 @@ import (
 	"syscall/js"
 
 	"cogentcore.org/core/base/errors"
+	"cogentcore.org/core/content/bcontent"
 )
 
 var (
@@ -52,6 +53,19 @@ func (ct *Content) getWebURL() string {
 
 // saveWebURL saves the current page URL to the user's address bar and history.
 func (ct *Content) saveWebURL() {
+	current, nw, err := ct.pageURL(ct.currentPage, ct.currentHeading)
+	if err != nil {
+		return
+	}
+	if nw.String() == current.String() {
+		return // We are already at this URL, so don't push it again
+	}
+	js.Global().Get("history").Call("pushState", "", "", nw.String())
+}
+
+// pageURL returns the full URL for the given page, with the heading
+// if non-empty.
+func (ct *Content) pageURL(pg *bcontent.Page, heading string) (current, nw *url.URL, err error) {
 	if firstContent == nil {
 		firstContent = ct
 	}
@@ -62,16 +76,13 @@ func (ct *Content) saveWebURL() {
 	if errors.Log(err) != nil {
 		return
 	}
-	new, err := url.Parse(ct.currentPage.URL)
+	cur, err := url.Parse(pg.URL)
 	if errors.Log(err) != nil {
 		return
 	}
-	new.Fragment = ct.currentHeading
-	fullNew := base.ResolveReference(new)
-	if fullNew.String() == current.String() {
-		return // We are already at this URL, so don't push it again
-	}
-	js.Global().Get("history").Call("pushState", "", "", fullNew.String())
+	cur.Fragment = heading
+	nw = base.ResolveReference(cur)
+	return
 }
 
 // handleWebPopState adds a JS event listener to handle user navigation in the browser.

--- a/content/url_js.go
+++ b/content/url_js.go
@@ -52,9 +52,9 @@ func (ct *Content) getWebURL() string {
 }
 
 // saveWebURL saves the current page URL to the user's address bar and history.
-func (ct *Content) saveWebURL() {
-	current, nw, err := ct.pageURL(ct.current.Page, ct.current.Heading)
-	if err != nil {
+func (ct *Content) saveWebURL(lc *Location) {
+	current, nw, err := ct.pageURL(lc.Page, lc.Heading)
+	if err != nil || nw == nil {
 		return
 	}
 	if nw.String() == current.String() {
@@ -73,7 +73,7 @@ func (ct *Content) pageURL(pg *bcontent.Page, heading string) (current, nw *url.
 		return
 	}
 	current, base, err := getURL()
-	if errors.Log(err) != nil {
+	if errors.Log(err) != nil || pg == nil {
 		return
 	}
 	cur, err := url.Parse(pg.URL)

--- a/content/url_js.go
+++ b/content/url_js.go
@@ -53,7 +53,7 @@ func (ct *Content) getWebURL() string {
 
 // saveWebURL saves the current page URL to the user's address bar and history.
 func (ct *Content) saveWebURL() {
-	current, nw, err := ct.pageURL(ct.currentPage, ct.currentHeading)
+	current, nw, err := ct.pageURL(ct.current.Page, ct.current.Heading)
 	if err != nil {
 		return
 	}

--- a/content/url_noop.go
+++ b/content/url_noop.go
@@ -22,5 +22,5 @@ func (ct *Content) getWebURL() string   { return "" }
 func (ct *Content) pageURL(pg *bcontent.Page, heading string) (current, nw *url.URL, err error) {
 	return
 }
-func (ct *Content) saveWebURL()        {}
-func (ct *Content) handleWebPopState() {}
+func (ct *Content) saveWebURL(lc *Location) {}
+func (ct *Content) handleWebPopState()      {}

--- a/content/url_noop.go
+++ b/content/url_noop.go
@@ -6,6 +6,12 @@
 
 package content
 
+import (
+	"net/url"
+
+	"cogentcore.org/core/content/bcontent"
+)
+
 // OfflineURL is the non-web base url, which can be set to allow
 // docs to refer to this in frontmatter.
 var OfflineURL = ""
@@ -13,5 +19,8 @@ var OfflineURL = ""
 // just for printing
 func (ct *Content) getPrintURL() string { return OfflineURL }
 func (ct *Content) getWebURL() string   { return "" }
-func (ct *Content) saveWebURL()         {}
-func (ct *Content) handleWebPopState()  {}
+func (ct *Content) pageURL(pg *bcontent.Page, heading string) (current, nw *url.URL, err error) {
+	return
+}
+func (ct *Content) saveWebURL()        {}
+func (ct *Content) handleWebPopState() {}

--- a/core/events.go
+++ b/core/events.go
@@ -1193,6 +1193,8 @@ func (em *Events) managerKeyChordEvents(e events.Event) {
 		if em.focusPrev() {
 			e.SetHandled()
 		}
+	case keymap.Find:
+		TextSearch(sc, "", true)
 	case keymap.WinSnapshot:
 		img := sc.Renderer.Image()
 		dstr := time.Now().Format(time.DateOnly + "-" + "15-04-05")

--- a/core/events.go
+++ b/core/events.go
@@ -267,11 +267,15 @@ func (em *Events) handlePosEvent(e events.Event) {
 			return
 		}
 		if !tree.IsNil(em.slide) {
-			em.slide.AsWidget().HandleEvent(e)
-			em.slide.AsWidget().Send(events.SlideMove, e)
-			e.SetHandled()
-			em.setCursorFromStyle()
-			return
+			if len(sc.selectedText) > 0 && !em.slide.AsWidget().posInScBBox(pos) {
+				// allow multi-select
+			} else {
+				em.slide.AsWidget().HandleEvent(e)
+				em.slide.AsWidget().Send(events.SlideMove, e)
+				e.SetHandled()
+				em.setCursorFromStyle()
+				return
+			}
 		}
 	case events.Scroll:
 		if !tree.IsNil(em.scroll) {
@@ -447,8 +451,31 @@ func (em *Events) handlePosEvent(e events.Event) {
 			} else if !tree.IsNil(em.slidePress) && em.dragStartCheck(e, TimingSettings.SlideStartTime, TimingSettings.DragStartDistance) {
 				em.cancelRepeatClick()
 				em.cancelLongPress()
-				em.slide = em.slidePress
-				em.slide.AsWidget().Send(events.SlideStart, e)
+				if em.slide != nil { // out of original bbox
+					got := false
+					for i := n - 1; i >= 0; i-- {
+						w := em.mouseInBBox[i]
+						if _, ok := w.(*Text); ok {
+							em.slide = w
+							got = true
+							break
+						}
+					}
+					slb := em.slide.AsWidget()
+					if pos.Y > slb.Geom.TotalBBox.Max.Y || pos.X > slb.Geom.TotalBBox.Max.X {
+						ec := e.Clone()
+						ec.AsBase().WhereLocal = slb.Geom.TotalBBox.Max
+						slb.Send(events.SlideMove, ec)
+					}
+					if got {
+						ec := e.Clone()
+						ec.AsBase().WhereLocal = slb.Geom.TotalBBox.Min
+						em.slide.AsWidget().Send(events.SlideStart, ec)
+					}
+				} else {
+					em.slide = em.slidePress
+					em.slide.AsWidget().Send(events.SlideStart, e)
+				}
 				e.SetHandled()
 			}
 		}

--- a/core/events.go
+++ b/core/events.go
@@ -1222,6 +1222,7 @@ func (em *Events) managerKeyChordEvents(e events.Event) {
 		}
 	case keymap.Find:
 		Search(sc, LastSearch, LastUseCase)
+		e.SetHandled()
 	case keymap.WinSnapshot:
 		img := sc.Renderer.Image()
 		dstr := time.Now().Format(time.DateOnly + "-" + "15-04-05")
@@ -1267,7 +1268,7 @@ func (em *Events) managerKeyChordEvents(e events.Event) {
 		AllRenderWindows.focusNext()
 	}
 	if !e.IsHandled() {
-		em.triggerShortcut(cs)
+		em.triggerShortcut(cs, e)
 	}
 }
 
@@ -1327,7 +1328,7 @@ func (em *Events) addShortcut(chord key.Chord, bt *Button) {
 // triggerShortcut attempts to trigger a shortcut, returning true if one was
 // triggered, and false otherwise.  Also eliminates any shortcuts with deleted
 // buttons, and does not trigger for Disabled buttons.
-func (em *Events) triggerShortcut(chord key.Chord) bool {
+func (em *Events) triggerShortcut(chord key.Chord, e events.Event) bool {
 	if DebugSettings.KeyEventTrace {
 		fmt.Printf("Shortcut chord: %v -- looking for button\n", chord)
 	}
@@ -1352,6 +1353,7 @@ func (em *Events) triggerShortcut(chord key.Chord) bool {
 	if DebugSettings.KeyEventTrace {
 		fmt.Printf("Shortcut chord: %v, button: %v triggered\n", chord, sa.Text)
 	}
+	e.SetHandled()
 	sa.Send(events.Click)
 	return true
 }

--- a/core/events.go
+++ b/core/events.go
@@ -1194,7 +1194,7 @@ func (em *Events) managerKeyChordEvents(e events.Event) {
 			e.SetHandled()
 		}
 	case keymap.Find:
-		TextSearch(sc, LastTextSearch, LastUseCase)
+		Search(sc, LastSearch, LastUseCase)
 	case keymap.WinSnapshot:
 		img := sc.Renderer.Image()
 		dstr := time.Now().Format(time.DateOnly + "-" + "15-04-05")

--- a/core/events.go
+++ b/core/events.go
@@ -1194,7 +1194,7 @@ func (em *Events) managerKeyChordEvents(e events.Event) {
 			e.SetHandled()
 		}
 	case keymap.Find:
-		TextSearch(sc, "", true)
+		TextSearch(sc, LastTextSearch, LastUseCase)
 	case keymap.WinSnapshot:
 		img := sc.Renderer.Image()
 		dstr := time.Now().Format(time.DateOnly + "-" + "15-04-05")

--- a/core/menu.go
+++ b/core/menu.go
@@ -218,6 +218,10 @@ type MenuSearcher interface {
 
 // standardContextMenu adds standard context menu items for the [Scene].
 func (sc *Scene) standardContextMenu(m *Scene) { //types:add
+	sdesc := "Search for text within all widgets in current scene."
+	NewButton(m).SetText("Search").SetIcon(icons.Search).SetKey(keymap.Find).SetTooltip(sdesc).OnClick(func(e events.Event) {
+		Search(sc, LastSearch, LastUseCase)
+	})
 	msdesc := "Search for menu buttons and other app actions"
 	NewButton(m).SetText("Menu search").SetIcon(icons.Search).SetKey(keymap.Menu).SetTooltip(msdesc).OnClick(func(e events.Event) {
 		sc.MenuSearchDialog("Menu search", msdesc)

--- a/core/scene.go
+++ b/core/scene.go
@@ -85,6 +85,10 @@ type Scene struct { //core:no-new
 	// selection mode is transmitted to the inspect editor after the user is done selecting.
 	selectedWidgetChan chan Widget `json:"-" xml:"-"`
 
+	// selectedText is a list of [Text] elements that have been selected,
+	// to support multi-text selection.
+	selectedText []*Text
+
 	// source renderer for rendering the scene
 	Renderer render.Renderer `copier:"-" json:"-" xml:"-" display:"-" set:"-"`
 

--- a/core/search.go
+++ b/core/search.go
@@ -1,0 +1,150 @@
+// Copyright (c) 2026, Cogent Core. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package core
+
+import (
+	"fmt"
+
+	"cogentcore.org/core/events"
+	"cogentcore.org/core/icons"
+	"cogentcore.org/core/styles"
+	"cogentcore.org/core/text/runes"
+	"cogentcore.org/core/text/textpos"
+	"cogentcore.org/core/tree"
+)
+
+// SearchResults are the search results for text within [Text] widgets.
+type SearchResults struct {
+	// Text is the widget
+	Text *Text
+
+	// Matches are the matching ranges within the RichText of widget.
+	Matches []textpos.Range
+}
+
+// TextSearchResults returns all of the [Text] widgets within given widget,
+// with matching text for the given find string, with given case sensitivity.
+func TextSearchResults(w Widget, find string, ignoreCase bool) []SearchResults {
+	fr := []rune(find)
+	fsz := len(fr)
+	var res []SearchResults
+	wb := w.AsWidget()
+	wb.WidgetWalkDown(func(cw Widget, cwb *WidgetBase) bool {
+		tx, ok := cw.(*Text)
+		if !ok {
+			return tree.Continue
+		}
+		rn := tx.richText.Join()
+
+		var matches []textpos.Range
+		sz := len(rn)
+		ci := 0
+		for ci < sz {
+			var i int
+			if ignoreCase {
+				i = runes.IndexFold(rn[ci:], fr)
+			} else {
+				i = runes.Index(rn[ci:], fr)
+			}
+			if i < 0 {
+				break
+			}
+			i += ci
+			ci = i + fsz
+			matches = append(matches, textpos.Range{Start: i, End: ci})
+		}
+		if len(matches) > 0 {
+			res = append(res, SearchResults{Text: tx, Matches: matches})
+		}
+		return tree.Continue
+	})
+	return res
+}
+
+// TextSearchHighlightReset resets the highlights within all [Text] elements
+// under given widget.
+func TextSearchHighlightReset(w Widget) {
+	wb := w.AsWidget()
+	wb.WidgetWalkDown(func(cw Widget, cwb *WidgetBase) bool {
+		tx, ok := cw.(*Text)
+		if !ok {
+			return tree.Continue
+		}
+		tx.highlights = nil
+		tx.NeedsRender()
+		return tree.Continue
+	})
+}
+
+// TextSearchHighlight adds region highlights for given text search results,
+// first calling [TextSearchHighlightReset] to reset any existing highlights.
+func TextSearchHighlight(w Widget, res []SearchResults) {
+	TextSearchHighlightReset(w)
+	for _, r := range res {
+		r.Text.highlights = r.Matches
+		r.Text.NeedsRender()
+	}
+}
+
+// TextSearch performs an interactive search for given text,
+// on elements within given widget.
+func TextSearch(w Widget, find string, ignoreCase bool) {
+	var res []SearchResults
+	var n int
+	idx := 0
+	search := func() {
+		res = TextSearchResults(w, find, ignoreCase)
+		TextSearchHighlight(w, res)
+		n = len(res)
+	}
+	search()
+
+	d := NewBody("Search")
+	d.Styler(func(s *styles.Style) {
+		s.Direction = styles.Row
+	})
+	st := NewTextField(d).SetText(find)
+
+	ix := NewText(d).SetText("00/00")
+	ix.Updater(func() {
+		ix.SetText(fmt.Sprintf("%d/%d", idx, n))
+	})
+	st.OnChange(func(e events.Event) {
+		find = st.Text()
+		search()
+		ix.Update()
+	})
+	up := NewButton(d).SetIcon(icons.ArrowUpward)
+	up.OnClick(func(e events.Event) {
+		if n == 0 {
+			return
+		}
+		idx--
+		if idx < 0 {
+			idx += n
+		}
+		ix.Update()
+		// todo: select
+	})
+	dn := NewButton(d).SetIcon(icons.ArrowDownward)
+	dn.OnClick(func(e events.Event) {
+		if n == 0 {
+			return
+		}
+		idx++
+		if idx >= n {
+			idx -= n
+		}
+		ix.Update()
+		// todo: select
+	})
+	x := NewButton(d).SetIcon(icons.Close)
+	x.OnClick(func(e events.Event) {
+		TextSearchHighlightReset(w)
+		d.Close()
+	})
+	d.RunDialog(w)
+
+}

--- a/core/search.go
+++ b/core/search.go
@@ -92,9 +92,13 @@ func TextSearchResults(w Widget, find string, useCase bool) SearchResults {
 	var res SearchResults
 	wb := w.AsWidget()
 	wb.WidgetWalkDown(func(cw Widget, cwb *WidgetBase) bool {
+		if !cwb.IsVisible() {
+			return tree.Break
+		}
 		matches := cw.TextSearch(find, useCase)
 		if len(matches) > 0 {
 			res = append(res, SearchResult{Widget: cw, Matches: matches})
+			return tree.Break
 		}
 		return tree.Continue
 	})
@@ -124,11 +128,7 @@ func TextSearchSelect(results SearchResults, index int, reset bool) {
 	if res == nil {
 		return
 	}
-	if reset {
-		res.Widget.SelectMatch(nil)
-		return
-	}
-	res.Widget.SelectMatch(&res.Matches[i])
+	res.Widget.SelectMatch(res.Matches, i, !reset, reset)
 }
 
 // TextSearch performs an interactive search for given text,

--- a/core/tabs.go
+++ b/core/tabs.go
@@ -259,9 +259,9 @@ func (ts *Tabs) insertTabButtonAt(label string, idx int) *Tab {
 	return tab
 }
 
-// tabAtIndex returns content frame and tab button at given index, nil if
+// TabAtIndex returns content frame and tab button at given index, nil if
 // index out of range (emits log message).
-func (ts *Tabs) tabAtIndex(idx int) (*Frame, *Tab) {
+func (ts *Tabs) TabAtIndex(idx int) (*Frame, *Tab) {
 	ts.mu.Lock()
 	defer ts.mu.Unlock()
 
@@ -280,7 +280,7 @@ func (ts *Tabs) tabAtIndex(idx int) (*Frame, *Tab) {
 // SelectTabIndex selects the tab at the given index, returning it or nil.
 // This is the final tab selection path.
 func (ts *Tabs) SelectTabIndex(idx int) *Frame {
-	frame, tab := ts.tabAtIndex(idx)
+	frame, tab := ts.TabAtIndex(idx)
 	if frame == nil {
 		return nil
 	}
@@ -362,7 +362,7 @@ func RecycleTabWidget[T tree.NodeValue](ts *Tabs, name string) *T {
 
 // DeleteTabIndex deletes the tab at the given index, returning whether it was successful.
 func (ts *Tabs) DeleteTabIndex(idx int) bool {
-	frame, _ := ts.tabAtIndex(idx)
+	frame, _ := ts.TabAtIndex(idx)
 	if frame == nil {
 		return false
 	}

--- a/core/tabs.go
+++ b/core/tabs.go
@@ -44,6 +44,11 @@ type Tabs struct {
 	// This can be used to update the new tab contents.
 	NewTabFunc func(index int)
 
+	// CloseFunc is a function that will be called when a tab is closed.
+	// with the index of the tab that was closed.
+	// This can be used to manage any additional resources associated with the tab.
+	CloseFunc func(index int)
+
 	// maxChars is the maximum number of characters to include in the tab text.
 	// It elides text that are longer than that.
 	maxChars int
@@ -392,6 +397,9 @@ func (ts *Tabs) DeleteTabIndex(idx int) bool {
 		ts.SelectTabIndex(nidx)
 	}
 	ts.NeedsLayout()
+	if ts.CloseFunc != nil {
+		ts.CloseFunc(idx)
+	}
 	return true
 }
 

--- a/core/tabs.go
+++ b/core/tabs.go
@@ -44,10 +44,10 @@ type Tabs struct {
 	// This can be used to update the new tab contents.
 	NewTabFunc func(index int)
 
-	// CloseFunc is a function that will be called when a tab is closed.
+	// CloseTabFunc is a function that will be called when a tab is closed.
 	// with the index of the tab that was closed.
 	// This can be used to manage any additional resources associated with the tab.
-	CloseFunc func(index int)
+	CloseTabFunc func(index int)
 
 	// maxChars is the maximum number of characters to include in the tab text.
 	// It elides text that are longer than that.
@@ -397,8 +397,8 @@ func (ts *Tabs) DeleteTabIndex(idx int) bool {
 		ts.SelectTabIndex(nidx)
 	}
 	ts.NeedsLayout()
-	if ts.CloseFunc != nil {
-		ts.CloseFunc(idx)
+	if ts.CloseTabFunc != nil {
+		ts.CloseTabFunc(idx)
 	}
 	return true
 }

--- a/core/tabs.go
+++ b/core/tabs.go
@@ -283,9 +283,9 @@ func (ts *Tabs) SelectTabIndex(idx int) *Frame {
 	ts.unselectOtherTabs(idx)
 	tab.SetSelected(true)
 	fr.StackTop = idx
+	ts.mu.Unlock()
 	fr.Update()
 	frame.DeferShown()
-	ts.mu.Unlock()
 	return frame
 }
 

--- a/core/tabs.go
+++ b/core/tabs.go
@@ -39,6 +39,11 @@ type Tabs struct {
 	// NewTabButton is whether to show a new tab button at the end of the list of tabs.
 	NewTabButton bool
 
+	// NewTabFunc is a function that will be called when the NewTabButton
+	// is clicked to create a new tab, with the index of this new tab.
+	// This can be used to update the new tab contents.
+	NewTabFunc func(index int)
+
 	// maxChars is the maximum number of characters to include in the tab text.
 	// It elides text that are longer than that.
 	maxChars int
@@ -151,7 +156,11 @@ func (ts *Tabs) Init() {
 				ntb.SetTooltip("Add a new tab").SetName("new-tab-button")
 				ntb.OnClick(func(e events.Event) {
 					ts.NewTab("New tab")
-					ts.SelectTabIndex(ts.NumTabs() - 1)
+					idx := ts.NumTabs() - 1
+					if ts.NewTabFunc != nil {
+						ts.NewTabFunc(idx)
+					}
+					ts.SelectTabIndex(idx)
 				})
 			})
 		})

--- a/core/text.go
+++ b/core/text.go
@@ -219,7 +219,7 @@ func (tx *Text) Init() {
 		}
 	})
 
-	tx.HandleTextClick(func(tl *rich.Hyperlink) {
+	tx.HandleTextClick(func(tl *rich.Hyperlink, e events.Event) {
 		system.TheApp.OpenURL(tl.URL)
 	})
 	tx.OnFocusLost(func(e events.Event) {
@@ -327,13 +327,13 @@ func (tx *Text) findLink(pos image.Point) (*rich.Hyperlink, image.Rectangle) {
 
 // HandleTextClick handles click events such that the given function will be called
 // on any links that are clicked on.
-func (tx *Text) HandleTextClick(openLink func(tl *rich.Hyperlink)) {
+func (tx *Text) HandleTextClick(openLink func(tl *rich.Hyperlink, e events.Event)) {
 	tx.OnClick(func(e events.Event) {
 		tl, _ := tx.findLink(e.Pos())
 		if tl == nil {
 			return
 		}
-		openLink(tl)
+		openLink(tl, e)
 		e.SetHandled()
 	})
 }

--- a/core/text.go
+++ b/core/text.go
@@ -531,7 +531,7 @@ func (tx *Text) Render() {
 	tx.Scene.Painter.DrawText(tx.paintText, tx.Geom.Pos.Content)
 }
 
-//////// TextSearch interface
+//////// Search interface
 
 // TextRunes returns any text content associated with the widget, to be used
 // for Search for example. If this is nil, then it is excluded from search.
@@ -539,30 +539,35 @@ func (tx *Text) TextRunes() []rune {
 	return tx.richText.Join()
 }
 
-// TextSearch returns text search results for this widget, searching for
+// Search returns text search results for this widget, searching for
 // the find string with given case sensitivity. It is up to each widget
 // to define the meaning of the Region line, char values for the matches.
-func (tx *Text) TextSearch(find string, useCase bool) []textpos.Match {
-	return TextSearchRunes(tx.richText.Join(), find, useCase)
+// The bool return value indicates whether this widget handled the search,
+// thereby excluding further searching within the elements under it.
+func (tx *Text) Search(find string, useCase bool) ([]textpos.Match, bool) {
+	return SearchRunes(tx.richText.Join(), find, useCase), true
 }
 
 // HighlightMatches does highlighting of the given matches within this widget,
-// where the matches are as returned from the TextSearch method.
+// where the matches are as returned from the Search method.
 // Passing a nil causes matches to be reset.
 // Any existing highlighting should always be reset first regardless.
-func (tx *Text) HighlightMatches(matches []textpos.Match) {
+// The bool return value indicates whether this widget handled the search,
+// thereby excluding further searching within the elements under it.
+func (tx *Text) HighlightMatches(matches []textpos.Match) bool {
 	tx.highlights = nil
 	tx.NeedsRender()
 	if matches == nil {
-		return
+		return true
 	}
 	for _, m := range matches {
 		tx.highlights = append(tx.highlights, textpos.Range{Start: m.Region.Start.Char, End: m.Region.End.Char})
 	}
+	return true
 }
 
 // SelectMatch selects match at given index from among those returned
-// from the TextSearch method. scroll = scroll widget into view.
+// from the Search method. scroll = scroll widget into view.
 // reset = clear selection instead of selecting (does not scroll).
 func (tx *Text) SelectMatch(matches []textpos.Match, index int, scroll, reset bool) {
 	if reset {

--- a/core/text.go
+++ b/core/text.go
@@ -391,8 +391,12 @@ func (tx *Text) selectUpdate(ri int) {
 	} else {
 		tx.selectRange.Start, tx.selectRange.End = ri, tx.selectRange.Start
 	}
-	tx.paintText.SelectReset()
-	tx.paintText.SelectRegion(tx.selectRange)
+}
+
+// SetSelectRange sets the selection range
+func (tx *Text) SetSelectRange(r textpos.Range) {
+	tx.selectRange = r
+	tx.NeedsRender()
 }
 
 // hasSelection returns true if there is an active selection.
@@ -536,6 +540,8 @@ func (tx *Text) SizeDown(iter int) bool {
 
 func (tx *Text) Render() {
 	tx.WidgetBase.Render()
+	tx.paintText.SelectReset()
+	tx.paintText.SelectRegion(tx.selectRange)
 	tx.paintText.HighlightReset()
 	tx.paintText.HighlightRegion(tx.highlights...)
 	tx.Scene.Painter.DrawText(tx.paintText, tx.Geom.Pos.Content)

--- a/core/text.go
+++ b/core/text.go
@@ -561,15 +561,18 @@ func (tx *Text) HighlightMatches(matches []textpos.Match) {
 	}
 }
 
-// SelectMatch selects given match from among those returned from the
-// TextSearch method. Should also scroll widget into view.
-// Passing a nil causes select to be reset.
-func (tx *Text) SelectMatch(match *textpos.Match) {
-	if match == nil {
+// SelectMatch selects match at given index from among those returned
+// from the TextSearch method. scroll = scroll widget into view.
+// reset = clear selection instead of selecting (does not scroll).
+func (tx *Text) SelectMatch(matches []textpos.Match, index int, scroll, reset bool) {
+	if reset {
 		tx.selectReset()
 		return
 	}
+	match := matches[index]
 	tx.selectRange = textpos.Range{Start: match.Region.Start.Char, End: match.Region.End.Char}
 	tx.NeedsRender()
-	tx.ScrollThisToTop()
+	if scroll {
+		tx.ScrollThisToTop()
+	}
 }

--- a/core/textfield.go
+++ b/core/textfield.go
@@ -1822,15 +1822,18 @@ func (tx *TextField) HighlightMatches(matches []textpos.Match) {
 	}
 }
 
-// SelectMatch selects given match from among those returned from the
-// TextSearch method. Should also scroll widget into view.
-// Passing a nil causes select to be reset.
-func (tx *TextField) SelectMatch(match *textpos.Match) {
-	if match == nil {
+// SelectMatch selects match at given index from among those returned
+// from the TextSearch method. scroll = scroll widget into view.
+// reset = clear selection instead of selecting (does not scroll).
+func (tx *TextField) SelectMatch(matches []textpos.Match, index int, scroll, reset bool) {
+	if reset {
 		tx.selectReset()
 		return
 	}
+	match := matches[index]
 	tx.selectRange = textpos.Range{Start: match.Region.Start.Char, End: match.Region.End.Char}
 	tx.NeedsRender()
-	tx.ScrollThisToTop()
+	if scroll {
+		tx.ScrollThisToTop()
+	}
 }

--- a/core/textfield.go
+++ b/core/textfield.go
@@ -143,6 +143,10 @@ type TextField struct { //core:embedder
 	// selectModeShift is whether selectmode was turned on because of the shift key.
 	selectModeShift bool
 
+	// highlights are regions that will be highlighted in the text
+	// when rendered. Indexes are into editText runes.
+	highlights []textpos.Range
+
 	// renderAll is the render version of entire text, for sizing.
 	renderAll *shaped.Lines
 
@@ -803,6 +807,12 @@ func (tf *TextField) hasSelection() bool {
 	return tf.selectRange.Start < tf.selectRange.End
 }
 
+// SetSelectRange sets the selection range
+func (tf *TextField) SetSelectRange(r textpos.Range) {
+	tf.selectRange = r
+	tf.NeedsRender()
+}
+
 // selection returns the currently selected text
 func (tf *TextField) selection() string {
 	if tf.hasSelection() {
@@ -1236,8 +1246,21 @@ func (tf *TextField) renderSelect() {
 	if effst == effed {
 		return
 	}
-	// fmt.Println("sel range:", effst, effed)
 	tf.renderVisible.SelectRegion(textpos.Range{effst, effed})
+}
+
+// renderHighlights renders the highlights regions, if any, underneath the text
+func (tf *TextField) renderHighlights() {
+	tf.renderVisible.HighlightReset()
+	dn := tf.dispRange.Len()
+	for _, r := range tf.highlights {
+		effst := max(0, r.Start-tf.dispRange.Start)
+		effed := min(dn, r.End-tf.dispRange.Start)
+		if effst == effed {
+			return
+		}
+		tf.renderVisible.HighlightRegion(textpos.Range{effst, effed})
+	}
 }
 
 // autoScroll scrolls the starting position to keep the cursor visible,
@@ -1755,6 +1778,7 @@ func (tf *TextField) Render() {
 		tf.layoutCurrent()
 	}
 	tf.updateCursorPosition()
+	tf.renderHighlights()
 	tf.renderSelect()
 	tf.Scene.Painter.DrawText(tf.renderVisible, tf.effPos)
 }
@@ -1766,4 +1790,47 @@ func concealDots(n int) []rune {
 		dots[i] = '•'
 	}
 	return dots
+}
+
+//////// TextSearch interface
+
+// TextRunes returns any text content associated with the widget, to be used
+// for Search for example. If this is nil, then it is excluded from search.
+func (tx *TextField) TextRunes() []rune {
+	return tx.editText
+}
+
+// TextSearch returns text search results for this widget, searching for
+// the find string with given case sensitivity. It is up to each widget
+// to define the meaning of the Region line, char values for the matches.
+func (tx *TextField) TextSearch(find string, useCase bool) []textpos.Match {
+	return TextSearchRunes(tx.editText, find, useCase)
+}
+
+// HighlightMatches does highlighting of the given matches within this widget,
+// where the matches are as returned from the TextSearch method.
+// Passing a nil causes matches to be reset.
+// Any existing highlighting should always be reset first regardless.
+func (tx *TextField) HighlightMatches(matches []textpos.Match) {
+	tx.highlights = nil
+	tx.NeedsRender()
+	if matches == nil {
+		return
+	}
+	for _, m := range matches {
+		tx.highlights = append(tx.highlights, textpos.Range{Start: m.Region.Start.Char, End: m.Region.End.Char})
+	}
+}
+
+// SelectMatch selects given match from among those returned from the
+// TextSearch method. Should also scroll widget into view.
+// Passing a nil causes select to be reset.
+func (tx *TextField) SelectMatch(match *textpos.Match) {
+	if match == nil {
+		tx.selectReset()
+		return
+	}
+	tx.selectRange = textpos.Range{Start: match.Region.Start.Char, End: match.Region.End.Char}
+	tx.NeedsRender()
+	tx.ScrollThisToTop()
 }

--- a/core/textfield.go
+++ b/core/textfield.go
@@ -1792,7 +1792,7 @@ func concealDots(n int) []rune {
 	return dots
 }
 
-//////// TextSearch interface
+//////// Search interface
 
 // TextRunes returns any text content associated with the widget, to be used
 // for Search for example. If this is nil, then it is excluded from search.
@@ -1800,30 +1800,35 @@ func (tx *TextField) TextRunes() []rune {
 	return tx.editText
 }
 
-// TextSearch returns text search results for this widget, searching for
+// Search returns text search results for this widget, searching for
 // the find string with given case sensitivity. It is up to each widget
 // to define the meaning of the Region line, char values for the matches.
-func (tx *TextField) TextSearch(find string, useCase bool) []textpos.Match {
-	return TextSearchRunes(tx.editText, find, useCase)
+// The bool return value indicates whether this widget handled the search,
+// thereby excluding further searching within the elements under it.
+func (tx *TextField) Search(find string, useCase bool) ([]textpos.Match, bool) {
+	return SearchRunes(tx.editText, find, useCase), true
 }
 
 // HighlightMatches does highlighting of the given matches within this widget,
-// where the matches are as returned from the TextSearch method.
+// where the matches are as returned from the Search method.
 // Passing a nil causes matches to be reset.
 // Any existing highlighting should always be reset first regardless.
-func (tx *TextField) HighlightMatches(matches []textpos.Match) {
+// The bool return value indicates whether this widget handled the search,
+// thereby excluding further searching within the elements under it.
+func (tx *TextField) HighlightMatches(matches []textpos.Match) bool {
 	tx.highlights = nil
 	tx.NeedsRender()
 	if matches == nil {
-		return
+		return true
 	}
 	for _, m := range matches {
 		tx.highlights = append(tx.highlights, textpos.Range{Start: m.Region.Start.Char, End: m.Region.End.Char})
 	}
+	return true
 }
 
 // SelectMatch selects match at given index from among those returned
-// from the TextSearch method. scroll = scroll widget into view.
+// from the Search method. scroll = scroll widget into view.
 // reset = clear selection instead of selecting (does not scroll).
 func (tx *TextField) SelectMatch(matches []textpos.Match, index int, scroll, reset bool) {
 	if reset {

--- a/core/tree.go
+++ b/core/tree.go
@@ -386,7 +386,7 @@ func (tr *Tree) Init() {
 		e.SetHandled()
 	})
 	parts.OnClick(func(e events.Event) {
-		tr.SelectEvent(e.SelectMode())
+		tr.SelectEvent(e.SelectMode(), e)
 		e.SetHandled()
 	})
 	parts.AsWidget().OnDoubleClick(func(e events.Event) {
@@ -420,7 +420,7 @@ func (tr *Tree) Init() {
 	parts.On(events.ContextMenu, func(e events.Event) {
 		sels := tr.GetSelectedNodes()
 		if len(sels) == 0 {
-			tr.SelectEvent(e.SelectMode())
+			tr.SelectEvent(e.SelectMode(), e)
 		}
 		tr.ShowContextMenu(e)
 	})
@@ -894,10 +894,10 @@ func (tr *Tree) sendChangeEventReSync(original ...events.Event) {
 // SelectEvent updates selection to include this node,
 // using selectmode from mouse event (ExtendContinuous, ExtendOne),
 // and root sends selection event. Returns true if event sent.
-func (tr *Tree) SelectEvent(mode events.SelectModes) bool {
+func (tr *Tree) SelectEvent(mode events.SelectModes, original ...events.Event) bool {
 	sel := tr.selectUpdate(mode)
 	if sel {
-		tr.sendSelectEvent()
+		tr.sendSelectEvent(original...)
 	}
 	return sel
 }

--- a/core/widget.go
+++ b/core/widget.go
@@ -21,6 +21,7 @@ import (
 	"cogentcore.org/core/styles/states"
 	"cogentcore.org/core/styles/units"
 	"cogentcore.org/core/system/composer"
+	"cogentcore.org/core/text/textpos"
 	"cogentcore.org/core/tree"
 	"golang.org/x/image/draw"
 )
@@ -136,6 +137,26 @@ type Widget interface {
 	// Use [Scene.AddDirectRender] to register such widgets with the Scene.
 	// The given draw operation is the suggested way to Draw onto existing images.
 	RenderSource(op draw.Op) composer.Source
+
+	// TextRunes returns any text content associated with the widget, to be used
+	// for Search for example. If this is nil, then it is excluded from search.
+	TextRunes() []rune
+
+	// TextSearch returns text search results for this widget, searching for
+	// the find string with given case sensitivity. It is up to each widget
+	// to define the meaning of the Region line, char values for the matches.
+	TextSearch(find string, useCase bool) []textpos.Match
+
+	// HighlightMatches does highlighting of the given matches within this widget,
+	// where the matches are as returned from the TextSearch method.
+	// Passing a nil causes matches to be reset.
+	// Any existing highlighting should always be reset first regardless.
+	HighlightMatches(matches []textpos.Match)
+
+	// SelectMatch selects given match from among those returned from the
+	// TextSearch method. Should also scroll widget into view.
+	// Passing a nil causes select to be reset.
+	SelectMatch(match *textpos.Match)
 }
 
 // WidgetBase implements the [Widget] interface and provides the core functionality
@@ -602,4 +623,31 @@ func widgetPrevFunc(w Widget, fun func(w Widget) bool) Widget {
 // which just returns [WidgetBase.Tooltip] and [WidgetBase.DefaultTooltipPos].
 func (wb *WidgetBase) WidgetTooltip(pos image.Point) (string, image.Point) {
 	return wb.Tooltip, wb.DefaultTooltipPos()
+}
+
+// TextRunes returns any text content associated with the widget, to be used
+// for Search for example. If this is nil, then it is excluded from search.
+func (wb *WidgetBase) TextRunes() []rune {
+	return nil
+}
+
+// TextSearch returns text search results for this widget, searching for
+// the find string with given case sensitivity. It is up to each widget
+// to define the meaning of the Region line, char values for the matches.
+func (wb *WidgetBase) TextSearch(find string, useCase bool) []textpos.Match {
+	return nil
+}
+
+// HighlightMatches does highlighting of the given matches within this widget,
+// where the matches are as returned from the TextSearch method.
+// Passing a nil causes matches to be reset.
+// Any existing highlighting should always be reset first regardless.
+func (wb *WidgetBase) HighlightMatches(matches []textpos.Match) {
+}
+
+// SelectMatch selects given match from among those returned from the
+// TextSearch method. Should also scroll widget into view.
+// Passing a nil causes select to be reset.
+func (wb *WidgetBase) SelectMatch(match *textpos.Match) {
+
 }

--- a/core/widget.go
+++ b/core/widget.go
@@ -153,10 +153,10 @@ type Widget interface {
 	// Any existing highlighting should always be reset first regardless.
 	HighlightMatches(matches []textpos.Match)
 
-	// SelectMatch selects given match from among those returned from the
-	// TextSearch method. Should also scroll widget into view.
-	// Passing a nil causes select to be reset.
-	SelectMatch(match *textpos.Match)
+	// SelectMatch selects match at given index from among those returned
+	// from the TextSearch method. scroll = scroll widget into view.
+	// reset = clear selection instead of selecting (does not scroll).
+	SelectMatch(matches []textpos.Match, index int, scroll, reset bool)
 }
 
 // WidgetBase implements the [Widget] interface and provides the core functionality
@@ -645,9 +645,9 @@ func (wb *WidgetBase) TextSearch(find string, useCase bool) []textpos.Match {
 func (wb *WidgetBase) HighlightMatches(matches []textpos.Match) {
 }
 
-// SelectMatch selects given match from among those returned from the
-// TextSearch method. Should also scroll widget into view.
-// Passing a nil causes select to be reset.
-func (wb *WidgetBase) SelectMatch(match *textpos.Match) {
+// SelectMatch selects match at given index from among those returned
+// from the TextSearch method. scroll = scroll widget into view.
+// reset = clear selection instead of selecting (does not scroll).
+func (wb *WidgetBase) SelectMatch(matches []textpos.Match, index int, scroll, reset bool) {
 
 }

--- a/core/widget.go
+++ b/core/widget.go
@@ -142,19 +142,23 @@ type Widget interface {
 	// for Search for example. If this is nil, then it is excluded from search.
 	TextRunes() []rune
 
-	// TextSearch returns text search results for this widget, searching for
+	// Search returns text search results for this widget, searching for
 	// the find string with given case sensitivity. It is up to each widget
 	// to define the meaning of the Region line, char values for the matches.
-	TextSearch(find string, useCase bool) []textpos.Match
+	// The bool return value indicates whether this widget handled the search,
+	// thereby excluding further searching within the elements under it.
+	Search(find string, useCase bool) ([]textpos.Match, bool)
 
 	// HighlightMatches does highlighting of the given matches within this widget,
-	// where the matches are as returned from the TextSearch method.
+	// where the matches are as returned from the Search method.
 	// Passing a nil causes matches to be reset.
 	// Any existing highlighting should always be reset first regardless.
-	HighlightMatches(matches []textpos.Match)
+	// The bool return value indicates whether this widget handled the search,
+	// thereby excluding further searching within the elements under it.
+	HighlightMatches(matches []textpos.Match) bool
 
 	// SelectMatch selects match at given index from among those returned
-	// from the TextSearch method. scroll = scroll widget into view.
+	// from the Search method. scroll = scroll widget into view.
 	// reset = clear selection instead of selecting (does not scroll).
 	SelectMatch(matches []textpos.Match, index int, scroll, reset bool)
 }
@@ -631,22 +635,27 @@ func (wb *WidgetBase) TextRunes() []rune {
 	return nil
 }
 
-// TextSearch returns text search results for this widget, searching for
+// Search returns text search results for this widget, searching for
 // the find string with given case sensitivity. It is up to each widget
 // to define the meaning of the Region line, char values for the matches.
-func (wb *WidgetBase) TextSearch(find string, useCase bool) []textpos.Match {
-	return nil
+// The bool return value indicates whether this widget handled the search,
+// thereby excluding further searching within the elements under it.
+func (wb *WidgetBase) Search(find string, useCase bool) ([]textpos.Match, bool) {
+	return nil, false
 }
 
 // HighlightMatches does highlighting of the given matches within this widget,
-// where the matches are as returned from the TextSearch method.
+// where the matches are as returned from the Search method.
 // Passing a nil causes matches to be reset.
 // Any existing highlighting should always be reset first regardless.
-func (wb *WidgetBase) HighlightMatches(matches []textpos.Match) {
+// The bool return value indicates whether this widget handled the search,
+// thereby excluding further searching within the elements under it.
+func (wb *WidgetBase) HighlightMatches(matches []textpos.Match) bool {
+	return false
 }
 
 // SelectMatch selects match at given index from among those returned
-// from the TextSearch method. scroll = scroll widget into view.
+// from the Search method. scroll = scroll widget into view.
 // reset = clear selection instead of selecting (does not scroll).
 func (wb *WidgetBase) SelectMatch(matches []textpos.Match, index int, scroll, reset bool) {
 

--- a/docs/content/tabs.md
+++ b/docs/content/tabs.md
@@ -63,7 +63,7 @@ You can make functional tabs, which can be closed:
 
 ```Go
 ts := core.NewTabs(b).SetType(core.FunctionalTabs)
-ts.CloseFunc = func(index int) {
+ts.CloseTabFunc = func(index int) {
 	core.MessageSnackbar(ts, "Tab was closed: " + strconv.Itoa(index))
 }
 ts.NewTab("First")

--- a/docs/content/tabs.md
+++ b/docs/content/tabs.md
@@ -48,6 +48,9 @@ You can allow users to add new tabs:
 
 ```Go
 ts := core.NewTabs(b).SetNewTabButton(true)
+ts.NewTabFunc = func(index int) {
+	core.MessageSnackbar(ts, "New tab created: " + strconv.Itoa(index))
+}
 ts.NewTab("First")
 ts.NewTab("Second")
 ```

--- a/docs/content/tabs.md
+++ b/docs/content/tabs.md
@@ -49,7 +49,9 @@ You can allow users to add new tabs:
 ```Go
 ts := core.NewTabs(b).SetNewTabButton(true)
 ts.NewTabFunc = func(index int) {
-	core.MessageSnackbar(ts, "New tab created: " + strconv.Itoa(index))
+    fr, tb := ts.TabAtIndex(index)
+	core.NewText(fr).SetText("This is the contents of tab: " + strconv.Itoa(index+1))
+	tb.SetText("Tab number " + strconv.Itoa(index+1)).Update()
 }
 ts.NewTab("First")
 ts.NewTab("Second")

--- a/docs/content/tabs.md
+++ b/docs/content/tabs.md
@@ -63,6 +63,9 @@ You can make functional tabs, which can be closed:
 
 ```Go
 ts := core.NewTabs(b).SetType(core.FunctionalTabs)
+ts.CloseFunc = func(index int) {
+	core.MessageSnackbar(ts, "Tab was closed: " + strconv.Itoa(index))
+}
 ts.NewTab("First")
 ts.NewTab("Second")
 ts.NewTab("Third")

--- a/docs/content/toolbar.md
+++ b/docs/content/toolbar.md
@@ -81,3 +81,23 @@ b.AddTopBar(func(bar *core.Frame) {
     })
 })
 ```
+
+You can grab the toolbar as the parent of a widget, and e.g., call [[Update]] on it as needed to enable or disable items based on other state (using the [[doc:core.WidgetBase.SetEnabled]] method):
+
+```go
+var toolbar *core.Toolbar
+
+b.AddTopBar(func(bar *core.Frame) {
+    core.NewToolbar(bar).Maker(func(p *tree.Plan) {
+        tree.Add(p, func(w *core.Button) {
+            toolbar = w.Parent.(*core.Toolbar)
+            w.SetText("Build")
+        })
+        tree.Add(p, func(w *core.Button) {
+            w.SetText("Run")
+        })
+    })
+})
+```
+
+

--- a/htmlcore/context.go
+++ b/htmlcore/context.go
@@ -56,7 +56,7 @@ type Context struct {
 
 	// OpenURL is the function used to open URLs,
 	// which defaults to [system.App.OpenURL].
-	OpenURL func(url string)
+	OpenURL func(url string, e events.Event)
 
 	// GetURL is the function used to get resources from URLs,
 	// which defaults to [http.Get].
@@ -105,7 +105,7 @@ type Context struct {
 func NewContext() *Context {
 	return &Context{
 		styles:            map[*html.Node][]*css.Rule{},
-		OpenURL:           system.TheApp.OpenURL,
+		OpenURL:           func(url string, e events.Event) { system.TheApp.OpenURL(url) },
 		GetURL:            http.Get,
 		ElementHandlers:   map[string]func(ctx *Context) bool{},
 		AttributeHandlers: map[string]func(ctx *Context, w io.Writer, node ast.Node, entering bool, tag, value string) bool{},
@@ -233,7 +233,7 @@ func (c *Context) LinkButton(bt *core.Button, url string) *core.Button {
 	bt.SetProperty("href", url)
 	bt.SetTooltip(url)
 	bt.OnClick(func(e events.Event) {
-		c.OpenURL(url)
+		c.OpenURL(url, e)
 	})
 	return bt
 }
@@ -248,7 +248,7 @@ func (c *Context) LinkButtonUpdating(bt *core.Button, url func() string) *core.B
 		bt.SetTooltip(u)
 	})
 	bt.OnClick(func(e events.Event) {
-		c.OpenURL(url())
+		c.OpenURL(url(), e)
 	})
 	return bt
 }

--- a/htmlcore/handler.go
+++ b/htmlcore/handler.go
@@ -108,6 +108,7 @@ func handleElement(ctx *Context) {
 		case "blockquote":
 			w.Styler(func(s *styles.Style) { // todo: need a better marker
 				s.Grow.Set(1, 0)
+				s.Direction = styles.Column
 				s.Background = colors.Scheme.SurfaceContainer
 			})
 		}

--- a/htmlcore/handler.go
+++ b/htmlcore/handler.go
@@ -17,6 +17,7 @@ import (
 	"cogentcore.org/core/base/iox/imagex"
 	"cogentcore.org/core/colors"
 	"cogentcore.org/core/core"
+	"cogentcore.org/core/events"
 	"cogentcore.org/core/styles"
 	"cogentcore.org/core/styles/states"
 	"cogentcore.org/core/text/lines"
@@ -415,8 +416,8 @@ func handleTextExclude(ctx *Context, excludeSubs ...string) (*core.Text, *html.N
 			s.Text.WhiteSpace = text.WhiteSpacePreWrap
 		})
 	}
-	tx.HandleTextClick(func(tl *rich.Hyperlink) {
-		ctx.OpenURL(tl.URL)
+	tx.HandleTextClick(func(tl *rich.Hyperlink, e events.Event) {
+		ctx.OpenURL(tl.URL, e)
 	})
 	return tx, excl
 }
@@ -430,8 +431,8 @@ func handleTextTag(ctx *Context) *core.Text {
 	start, end := nodeString(ctx.Node)
 	str := start + ExtractText(ctx) + end
 	tx := New[core.Text](ctx).SetText(str)
-	tx.HandleTextClick(func(tl *rich.Hyperlink) {
-		ctx.OpenURL(tl.URL)
+	tx.HandleTextClick(func(tl *rich.Hyperlink, e events.Event) {
+		ctx.OpenURL(tl.URL, e)
 	})
 	return tx
 }

--- a/math32/quaternion.go
+++ b/math32/quaternion.go
@@ -114,9 +114,25 @@ func (q *Quat) SetFromEuler(euler Vector3) {
 // ToEuler returns a Vector3 with components as the Euler angles
 // from the given quaternion.
 func (q Quat) ToEuler() Vector3 {
-	rot := Vector3{}
-	rot.SetEulerAnglesFromQuat(q)
-	return rot
+	// columns
+	x := q.MulVector(Vec3(1, 0, 0))
+	y := q.MulVector(Vec3(0, 1, 0))
+	z := q.MulVector(Vec3(0, 0, 1))
+
+	phi := Atan2(z.Y, z.Z)
+	sinp := -z.X
+	var theta float32
+	if Abs(sinp) >= 1 {
+		theta = 0.5 * Pi * Sign(sinp)
+	} else {
+		theta = Asin(sinp)
+	}
+	psi := Atan2(y.X, x.X)
+
+	return Vec3(-phi, -theta, -psi)
+	// rot := Vector3{}
+	// rot.SetEulerAnglesFromQuat(q)
+	// return rot
 }
 
 // SetFromAxisAngle sets this quaternion with the rotation

--- a/math32/quaternion_test.go
+++ b/math32/quaternion_test.go
@@ -34,6 +34,23 @@ func TestQuatSetFromAxisAngle(t *testing.T) {
 	expected := Quat{X: 0.7071068, Y: 0, Z: 0, W: 0.70710677}
 
 	assert.Equal(t, expected, q)
+
+	ta := q.ToAxisAngle()
+	tolassert.Equal(t, axis.X, ta.X)
+	tolassert.Equal(t, axis.Y, ta.Y)
+	tolassert.Equal(t, axis.Z, ta.Z)
+}
+
+func TestQuatToEuler(t *testing.T) {
+	axis := Vector3{X: 1, Y: 0, Z: 0}
+
+	q := Quat{}
+	q.SetFromAxisAngle(axis, Pi/2)
+
+	te := q.ToEuler()
+	tolassert.Equal(t, Pi/2, te.X)
+	tolassert.Equal(t, 0, te.Y)
+	tolassert.Equal(t, 0, te.Z)
 }
 
 func TestQuatSetFromRotationMatrix(t *testing.T) {

--- a/paint/renderers/htmlcanvas/text.go
+++ b/paint/renderers/htmlcanvas/text.go
@@ -91,8 +91,8 @@ func (rs *Renderer) TextRunRegions(ctx *render.Context, run *shapedgt.Run, ln *s
 	if run.Background != nil {
 		rs.FillBounds(ctx, rbb, run.Background)
 	}
-	rs.TextRegionFill(ctx, run, off, lns.SelectionColor, ln.Selections)
 	rs.TextRegionFill(ctx, run, off, lns.HighlightColor, ln.Highlights)
+	rs.TextRegionFill(ctx, run, off, lns.SelectionColor, ln.Selections)
 }
 
 // TextRun rasterizes the given text run into the output image using the

--- a/paint/renderers/rasterx/text.go
+++ b/paint/renderers/rasterx/text.go
@@ -102,8 +102,8 @@ func (rs *Renderer) TextRunRegions(ctx *render.Context, run *shapedgt.Run, ln *s
 	if run.Background != nil {
 		rs.FillBounds(ctx, rbb, run.Background)
 	}
-	rs.TextRegionFill(ctx, run, off, lns.SelectionColor, ln.Selections)
 	rs.TextRegionFill(ctx, run, off, lns.HighlightColor, ln.Highlights)
+	rs.TextRegionFill(ctx, run, off, lns.SelectionColor, ln.Selections)
 }
 
 // TextRun rasterizes the given text run into the output image using the

--- a/text/shaped/regions.go
+++ b/text/shaped/regions.go
@@ -31,16 +31,18 @@ func (ls *Lines) SelectReset() {
 	}
 }
 
-// HighlightRegion adds the selection to given region of runes from
+// HighlightRegion adds the selection(s) to given region of runes from
 // the original source runes. Use HighlightReset to clear first if desired.
-func (ls *Lines) HighlightRegion(r textpos.Range) {
+func (ls *Lines) HighlightRegion(rs ...textpos.Range) {
 	nr := ls.Source.Len()
-	r = r.Intersect(textpos.Range{0, nr})
-	for li := range ls.Lines {
-		ln := &ls.Lines[li]
-		lr := r.Intersect(ln.SourceRange)
-		if lr.Len() > 0 {
-			ln.Highlights = append(ln.Highlights, lr)
+	for _, r := range rs {
+		r = r.Intersect(textpos.Range{0, nr})
+		for li := range ls.Lines {
+			ln := &ls.Lines[li]
+			lr := r.Intersect(ln.SourceRange)
+			if lr.Len() > 0 {
+				ln.Highlights = append(ln.Highlights, lr)
+			}
 		}
 	}
 }

--- a/undo/undo.go
+++ b/undo/undo.go
@@ -8,7 +8,7 @@ representations of any kind of state representation (typically JSON dump of the 
 state). It stores the compact diffs from one state change to the next, with raw copies saved
 at infrequent intervals to tradeoff cost of computing diffs.
 
-In addition state (which is optional on any given step), a description of the action
+In addition to state (which is optional on any given step), a description of the action
 and arbitrary string-encoded data can be saved with each record.  Thus, for cases
 where the state doesn't change, you can just save some data about the action sufficient
 to undo / redo it.
@@ -74,16 +74,20 @@ func (rc *Record) Init(action, data string) {
 // Stack is the undo stack manager that manages the undo and redo process.
 type Stack struct {
 
-	// current index in the undo records -- this is the record that will be undone if user hits undo
+	// Index is the current index in the undo records.
+	// This is the record that will be undone if user hits undo.
 	Index int
 
-	// the list of saved state / action records
+	// Records is the list of saved state / action records.
 	Records []*Record
 
-	// interval for saving raw data -- need to do this at some interval to prevent having it take too long to compute patches from all the diffs.
+	// RawInterval is the interval for saving raw data.
+	// Need to do this at some interval to prevent having it take too long
+	// to compute patches from all the diffs.
 	RawInterval int
 
-	// mutex that protects updates -- we do diff computation as a separate goroutine so it is instant from perspective of UI
+	// Mu mutex that protects updates. Diff computation runs as a separate
+	// goroutine so it is instant from perspective of UI.
 	Mu sync.Mutex
 }
 

--- a/yaegicore/coresymbols/cogentcore_org-core-content.go
+++ b/yaegicore/coresymbols/cogentcore_org-core-content.go
@@ -18,6 +18,8 @@ func init() {
 
 		// type definitions
 		"Content":      reflect.ValueOf((*content.Content)(nil)),
+		"History":      reflect.ValueOf((*content.History)(nil)),
+		"Location":     reflect.ValueOf((*content.Location)(nil)),
 		"SettingsData": reflect.ValueOf((*content.SettingsData)(nil)),
 	}
 }

--- a/yaegicore/coresymbols/cogentcore_org-core-core.go
+++ b/yaegicore/coresymbols/cogentcore_org-core-core.go
@@ -9,6 +9,7 @@ import (
 	"cogentcore.org/core/math32"
 	"cogentcore.org/core/styles"
 	"cogentcore.org/core/system/composer"
+	"cogentcore.org/core/text/textpos"
 	"cogentcore.org/core/tree"
 	"github.com/cogentcore/yaegi/interp"
 	"go/constant"
@@ -63,8 +64,11 @@ func init() {
 		"GenerateHTML":                  reflect.ValueOf(&core.GenerateHTML).Elem(),
 		"GenerateHTMLCore":              reflect.ValueOf(core.GenerateHTMLCore),
 		"HighlightingEditor":            reflect.ValueOf(core.HighlightingEditor),
+		"IgnoreCase":                    reflect.ValueOf(core.IgnoreCase),
 		"InitValueButton":               reflect.ValueOf(core.InitValueButton),
 		"InspectorWindow":               reflect.ValueOf(core.InspectorWindow),
+		"LastSearch":                    reflect.ValueOf(&core.LastSearch).Elem(),
+		"LastUseCase":                   reflect.ValueOf(&core.LastUseCase).Elem(),
 		"LayoutPassesN":                 reflect.ValueOf(core.LayoutPassesN),
 		"LayoutPassesValues":            reflect.ValueOf(core.LayoutPassesValues),
 		"ListColProperty":               reflect.ValueOf(constant.MakeFromLiteral("\"ls-col\"", token.STRING, 0)),
@@ -153,6 +157,15 @@ func init() {
 		"SaveSettings":                  reflect.ValueOf(core.SaveSettings),
 		"SceneSource":                   reflect.ValueOf(core.SceneSource),
 		"ScrimSource":                   reflect.ValueOf(core.ScrimSource),
+		"Search":                        reflect.ValueOf(core.Search),
+		"SearchHighlight":               reflect.ValueOf(core.SearchHighlight),
+		"SearchRunes":                   reflect.ValueOf(core.SearchRunes),
+		"SearchSelect":                  reflect.ValueOf(core.SearchSelect),
+		"SearchWidgets":                 reflect.ValueOf(core.SearchWidgets),
+		"SelectNoScroll":                reflect.ValueOf(core.SelectNoScroll),
+		"SelectReset":                   reflect.ValueOf(core.SelectReset),
+		"SelectScroll":                  reflect.ValueOf(core.SelectScroll),
+		"SelectSet":                     reflect.ValueOf(core.SelectSet),
 		"SettingsEditor":                reflect.ValueOf(core.SettingsEditor),
 		"SettingsWindow":                reflect.ValueOf(core.SettingsWindow),
 		"SizeClassesN":                  reflect.ValueOf(core.SizeClassesN),
@@ -225,6 +238,7 @@ func init() {
 		"TooltipStage":                  reflect.ValueOf(core.TooltipStage),
 		"UpdateAll":                     reflect.ValueOf(core.UpdateAll),
 		"UpdateSettings":                reflect.ValueOf(core.UpdateSettings),
+		"UseCase":                       reflect.ValueOf(core.UseCase),
 		"ValueTypes":                    reflect.ValueOf(&core.ValueTypes).Elem(),
 		"Wait":                          reflect.ValueOf(core.Wait),
 		"WindowStage":                   reflect.ValueOf(core.WindowStage),
@@ -297,6 +311,8 @@ func init() {
 		"SVG":                    reflect.ValueOf((*core.SVG)(nil)),
 		"Scene":                  reflect.ValueOf((*core.Scene)(nil)),
 		"ScreenSettings":         reflect.ValueOf((*core.ScreenSettings)(nil)),
+		"SearchResult":           reflect.ValueOf((*core.SearchResult)(nil)),
+		"SearchResults":          reflect.ValueOf((*core.SearchResults)(nil)),
 		"Separator":              reflect.ValueOf((*core.Separator)(nil)),
 		"Settings":               reflect.ValueOf((*core.Settings)(nil)),
 		"SettingsBase":           reflect.ValueOf((*core.SettingsBase)(nil)),
@@ -402,6 +418,7 @@ type _cogentcore_org_core_core_Layouter struct {
 	WContextMenuPos    func(e events.Event) image.Point
 	WCopyFieldsFrom    func(from tree.Node)
 	WDestroy           func()
+	WHighlightMatches  func(matches []textpos.Match) bool
 	WInit              func()
 	WLayoutSpace       func()
 	WManageOverflow    func(iter int, updateSize bool) bool
@@ -415,6 +432,8 @@ type _cogentcore_org_core_core_Layouter struct {
 	WScrollChanged     func(d math32.Dims, sb *core.Slider)
 	WScrollGeom        func(d math32.Dims) (pos math32.Vector2, sz math32.Vector2)
 	WScrollValues      func(d math32.Dims) (maxSize float32, visSize float32, visPct float32)
+	WSearch            func(find string, useCase bool) ([]textpos.Match, bool)
+	WSelectMatch       func(matches []textpos.Match, index int, scroll bool, reset bool)
 	WSetScrollParams   func(d math32.Dims, sb *core.Slider)
 	WShowContextMenu   func(e events.Event)
 	WSizeDown          func(iter int) bool
@@ -423,6 +442,7 @@ type _cogentcore_org_core_core_Layouter struct {
 	WSizeFromChildren  func(iter int, pass core.LayoutPasses) math32.Vector2
 	WSizeUp            func()
 	WStyle             func()
+	WTextRunes         func() []rune
 	WWidgetTooltip     func(pos image.Point) (string, image.Point)
 }
 
@@ -438,8 +458,11 @@ func (W _cogentcore_org_core_core_Layouter) ContextMenuPos(e events.Event) image
 }
 func (W _cogentcore_org_core_core_Layouter) CopyFieldsFrom(from tree.Node) { W.WCopyFieldsFrom(from) }
 func (W _cogentcore_org_core_core_Layouter) Destroy()                      { W.WDestroy() }
-func (W _cogentcore_org_core_core_Layouter) Init()                         { W.WInit() }
-func (W _cogentcore_org_core_core_Layouter) LayoutSpace()                  { W.WLayoutSpace() }
+func (W _cogentcore_org_core_core_Layouter) HighlightMatches(matches []textpos.Match) bool {
+	return W.WHighlightMatches(matches)
+}
+func (W _cogentcore_org_core_core_Layouter) Init()        { W.WInit() }
+func (W _cogentcore_org_core_core_Layouter) LayoutSpace() { W.WLayoutSpace() }
 func (W _cogentcore_org_core_core_Layouter) ManageOverflow(iter int, updateSize bool) bool {
 	return W.WManageOverflow(iter, updateSize)
 }
@@ -463,6 +486,12 @@ func (W _cogentcore_org_core_core_Layouter) ScrollGeom(d math32.Dims) (pos math3
 func (W _cogentcore_org_core_core_Layouter) ScrollValues(d math32.Dims) (maxSize float32, visSize float32, visPct float32) {
 	return W.WScrollValues(d)
 }
+func (W _cogentcore_org_core_core_Layouter) Search(find string, useCase bool) ([]textpos.Match, bool) {
+	return W.WSearch(find, useCase)
+}
+func (W _cogentcore_org_core_core_Layouter) SelectMatch(matches []textpos.Match, index int, scroll bool, reset bool) {
+	W.WSelectMatch(matches, index, scroll, reset)
+}
 func (W _cogentcore_org_core_core_Layouter) SetScrollParams(d math32.Dims, sb *core.Slider) {
 	W.WSetScrollParams(d, sb)
 }
@@ -473,8 +502,9 @@ func (W _cogentcore_org_core_core_Layouter) SizeFinal()                     { W.
 func (W _cogentcore_org_core_core_Layouter) SizeFromChildren(iter int, pass core.LayoutPasses) math32.Vector2 {
 	return W.WSizeFromChildren(iter, pass)
 }
-func (W _cogentcore_org_core_core_Layouter) SizeUp() { W.WSizeUp() }
-func (W _cogentcore_org_core_core_Layouter) Style()  { W.WStyle() }
+func (W _cogentcore_org_core_core_Layouter) SizeUp()           { W.WSizeUp() }
+func (W _cogentcore_org_core_core_Layouter) Style()            { W.WStyle() }
+func (W _cogentcore_org_core_core_Layouter) TextRunes() []rune { return W.WTextRunes() }
 func (W _cogentcore_org_core_core_Layouter) WidgetTooltip(pos image.Point) (string, image.Point) {
 	return W.WWidgetTooltip(pos)
 }
@@ -674,6 +704,7 @@ type _cogentcore_org_core_core_Treer struct {
 	WDestroy          func()
 	WDragDrop         func(e events.Event)
 	WDropDeleteSource func(e events.Event)
+	WHighlightMatches func(matches []textpos.Match) bool
 	WInit             func()
 	WMimeData         func(md *mimedata.Mimes)
 	WNodeWalkDown     func(fun func(n tree.Node) bool)
@@ -686,11 +717,14 @@ type _cogentcore_org_core_core_Treer struct {
 	WRender           func()
 	WRenderSource     func(op draw.Op) composer.Source
 	WRenderWidget     func()
+	WSearch           func(find string, useCase bool) ([]textpos.Match, bool)
+	WSelectMatch      func(matches []textpos.Match, index int, scroll bool, reset bool)
 	WShowContextMenu  func(e events.Event)
 	WSizeDown         func(iter int) bool
 	WSizeFinal        func()
 	WSizeUp           func()
 	WStyle            func()
+	WTextRunes        func() []rune
 	WWidgetTooltip    func(pos image.Point) (string, image.Point)
 }
 
@@ -712,8 +746,11 @@ func (W _cogentcore_org_core_core_Treer) DeleteSelected()                 { W.WD
 func (W _cogentcore_org_core_core_Treer) Destroy()                        { W.WDestroy() }
 func (W _cogentcore_org_core_core_Treer) DragDrop(e events.Event)         { W.WDragDrop(e) }
 func (W _cogentcore_org_core_core_Treer) DropDeleteSource(e events.Event) { W.WDropDeleteSource(e) }
-func (W _cogentcore_org_core_core_Treer) Init()                           { W.WInit() }
-func (W _cogentcore_org_core_core_Treer) MimeData(md *mimedata.Mimes)     { W.WMimeData(md) }
+func (W _cogentcore_org_core_core_Treer) HighlightMatches(matches []textpos.Match) bool {
+	return W.WHighlightMatches(matches)
+}
+func (W _cogentcore_org_core_core_Treer) Init()                       { W.WInit() }
+func (W _cogentcore_org_core_core_Treer) MimeData(md *mimedata.Mimes) { W.WMimeData(md) }
 func (W _cogentcore_org_core_core_Treer) NodeWalkDown(fun func(n tree.Node) bool) {
 	W.WNodeWalkDown(fun)
 }
@@ -727,12 +764,19 @@ func (W _cogentcore_org_core_core_Treer) Render()          { W.WRender() }
 func (W _cogentcore_org_core_core_Treer) RenderSource(op draw.Op) composer.Source {
 	return W.WRenderSource(op)
 }
-func (W _cogentcore_org_core_core_Treer) RenderWidget()                  { W.WRenderWidget() }
+func (W _cogentcore_org_core_core_Treer) RenderWidget() { W.WRenderWidget() }
+func (W _cogentcore_org_core_core_Treer) Search(find string, useCase bool) ([]textpos.Match, bool) {
+	return W.WSearch(find, useCase)
+}
+func (W _cogentcore_org_core_core_Treer) SelectMatch(matches []textpos.Match, index int, scroll bool, reset bool) {
+	W.WSelectMatch(matches, index, scroll, reset)
+}
 func (W _cogentcore_org_core_core_Treer) ShowContextMenu(e events.Event) { W.WShowContextMenu(e) }
 func (W _cogentcore_org_core_core_Treer) SizeDown(iter int) bool         { return W.WSizeDown(iter) }
 func (W _cogentcore_org_core_core_Treer) SizeFinal()                     { W.WSizeFinal() }
 func (W _cogentcore_org_core_core_Treer) SizeUp()                        { W.WSizeUp() }
 func (W _cogentcore_org_core_core_Treer) Style()                         { W.WStyle() }
+func (W _cogentcore_org_core_core_Treer) TextRunes() []rune              { return W.WTextRunes() }
 func (W _cogentcore_org_core_core_Treer) WidgetTooltip(pos image.Point) (string, image.Point) {
 	return W.WWidgetTooltip(pos)
 }
@@ -747,29 +791,33 @@ func (W _cogentcore_org_core_core_Validator) Validate() error { return W.WValida
 
 // _cogentcore_org_core_core_Value is an interface wrapper for Value type
 type _cogentcore_org_core_core_Value struct {
-	IValue           interface{}
-	WApplyScenePos   func()
-	WAsTree          func() *tree.NodeBase
-	WAsWidget        func() *core.WidgetBase
-	WChildBackground func(child core.Widget) image.Image
-	WContextMenuPos  func(e events.Event) image.Point
-	WCopyFieldsFrom  func(from tree.Node)
-	WDestroy         func()
-	WInit            func()
-	WNodeWalkDown    func(fun func(n tree.Node) bool)
-	WOnAdd           func()
-	WPlanName        func() string
-	WPosition        func()
-	WRender          func()
-	WRenderSource    func(op draw.Op) composer.Source
-	WRenderWidget    func()
-	WShowContextMenu func(e events.Event)
-	WSizeDown        func(iter int) bool
-	WSizeFinal       func()
-	WSizeUp          func()
-	WStyle           func()
-	WWidgetTooltip   func(pos image.Point) (string, image.Point)
-	WWidgetValue     func() any
+	IValue            interface{}
+	WApplyScenePos    func()
+	WAsTree           func() *tree.NodeBase
+	WAsWidget         func() *core.WidgetBase
+	WChildBackground  func(child core.Widget) image.Image
+	WContextMenuPos   func(e events.Event) image.Point
+	WCopyFieldsFrom   func(from tree.Node)
+	WDestroy          func()
+	WHighlightMatches func(matches []textpos.Match) bool
+	WInit             func()
+	WNodeWalkDown     func(fun func(n tree.Node) bool)
+	WOnAdd            func()
+	WPlanName         func() string
+	WPosition         func()
+	WRender           func()
+	WRenderSource     func(op draw.Op) composer.Source
+	WRenderWidget     func()
+	WSearch           func(find string, useCase bool) ([]textpos.Match, bool)
+	WSelectMatch      func(matches []textpos.Match, index int, scroll bool, reset bool)
+	WShowContextMenu  func(e events.Event)
+	WSizeDown         func(iter int) bool
+	WSizeFinal        func()
+	WSizeUp           func()
+	WStyle            func()
+	WTextRunes        func() []rune
+	WWidgetTooltip    func(pos image.Point) (string, image.Point)
+	WWidgetValue      func() any
 }
 
 func (W _cogentcore_org_core_core_Value) ApplyScenePos()             { W.WApplyScenePos() }
@@ -783,7 +831,10 @@ func (W _cogentcore_org_core_core_Value) ContextMenuPos(e events.Event) image.Po
 }
 func (W _cogentcore_org_core_core_Value) CopyFieldsFrom(from tree.Node) { W.WCopyFieldsFrom(from) }
 func (W _cogentcore_org_core_core_Value) Destroy()                      { W.WDestroy() }
-func (W _cogentcore_org_core_core_Value) Init()                         { W.WInit() }
+func (W _cogentcore_org_core_core_Value) HighlightMatches(matches []textpos.Match) bool {
+	return W.WHighlightMatches(matches)
+}
+func (W _cogentcore_org_core_core_Value) Init() { W.WInit() }
 func (W _cogentcore_org_core_core_Value) NodeWalkDown(fun func(n tree.Node) bool) {
 	W.WNodeWalkDown(fun)
 }
@@ -794,12 +845,19 @@ func (W _cogentcore_org_core_core_Value) Render()          { W.WRender() }
 func (W _cogentcore_org_core_core_Value) RenderSource(op draw.Op) composer.Source {
 	return W.WRenderSource(op)
 }
-func (W _cogentcore_org_core_core_Value) RenderWidget()                  { W.WRenderWidget() }
+func (W _cogentcore_org_core_core_Value) RenderWidget() { W.WRenderWidget() }
+func (W _cogentcore_org_core_core_Value) Search(find string, useCase bool) ([]textpos.Match, bool) {
+	return W.WSearch(find, useCase)
+}
+func (W _cogentcore_org_core_core_Value) SelectMatch(matches []textpos.Match, index int, scroll bool, reset bool) {
+	W.WSelectMatch(matches, index, scroll, reset)
+}
 func (W _cogentcore_org_core_core_Value) ShowContextMenu(e events.Event) { W.WShowContextMenu(e) }
 func (W _cogentcore_org_core_core_Value) SizeDown(iter int) bool         { return W.WSizeDown(iter) }
 func (W _cogentcore_org_core_core_Value) SizeFinal()                     { W.WSizeFinal() }
 func (W _cogentcore_org_core_core_Value) SizeUp()                        { W.WSizeUp() }
 func (W _cogentcore_org_core_core_Value) Style()                         { W.WStyle() }
+func (W _cogentcore_org_core_core_Value) TextRunes() []rune              { return W.WTextRunes() }
 func (W _cogentcore_org_core_core_Value) WidgetTooltip(pos image.Point) (string, image.Point) {
 	return W.WWidgetTooltip(pos)
 }
@@ -825,28 +883,32 @@ func (W _cogentcore_org_core_core_Valuer) Widget() core.Value { return W.WWidget
 
 // _cogentcore_org_core_core_Widget is an interface wrapper for Widget type
 type _cogentcore_org_core_core_Widget struct {
-	IValue           interface{}
-	WApplyScenePos   func()
-	WAsTree          func() *tree.NodeBase
-	WAsWidget        func() *core.WidgetBase
-	WChildBackground func(child core.Widget) image.Image
-	WContextMenuPos  func(e events.Event) image.Point
-	WCopyFieldsFrom  func(from tree.Node)
-	WDestroy         func()
-	WInit            func()
-	WNodeWalkDown    func(fun func(n tree.Node) bool)
-	WOnAdd           func()
-	WPlanName        func() string
-	WPosition        func()
-	WRender          func()
-	WRenderSource    func(op draw.Op) composer.Source
-	WRenderWidget    func()
-	WShowContextMenu func(e events.Event)
-	WSizeDown        func(iter int) bool
-	WSizeFinal       func()
-	WSizeUp          func()
-	WStyle           func()
-	WWidgetTooltip   func(pos image.Point) (string, image.Point)
+	IValue            interface{}
+	WApplyScenePos    func()
+	WAsTree           func() *tree.NodeBase
+	WAsWidget         func() *core.WidgetBase
+	WChildBackground  func(child core.Widget) image.Image
+	WContextMenuPos   func(e events.Event) image.Point
+	WCopyFieldsFrom   func(from tree.Node)
+	WDestroy          func()
+	WHighlightMatches func(matches []textpos.Match) bool
+	WInit             func()
+	WNodeWalkDown     func(fun func(n tree.Node) bool)
+	WOnAdd            func()
+	WPlanName         func() string
+	WPosition         func()
+	WRender           func()
+	WRenderSource     func(op draw.Op) composer.Source
+	WRenderWidget     func()
+	WSearch           func(find string, useCase bool) ([]textpos.Match, bool)
+	WSelectMatch      func(matches []textpos.Match, index int, scroll bool, reset bool)
+	WShowContextMenu  func(e events.Event)
+	WSizeDown         func(iter int) bool
+	WSizeFinal        func()
+	WSizeUp           func()
+	WStyle            func()
+	WTextRunes        func() []rune
+	WWidgetTooltip    func(pos image.Point) (string, image.Point)
 }
 
 func (W _cogentcore_org_core_core_Widget) ApplyScenePos()             { W.WApplyScenePos() }
@@ -860,7 +922,10 @@ func (W _cogentcore_org_core_core_Widget) ContextMenuPos(e events.Event) image.P
 }
 func (W _cogentcore_org_core_core_Widget) CopyFieldsFrom(from tree.Node) { W.WCopyFieldsFrom(from) }
 func (W _cogentcore_org_core_core_Widget) Destroy()                      { W.WDestroy() }
-func (W _cogentcore_org_core_core_Widget) Init()                         { W.WInit() }
+func (W _cogentcore_org_core_core_Widget) HighlightMatches(matches []textpos.Match) bool {
+	return W.WHighlightMatches(matches)
+}
+func (W _cogentcore_org_core_core_Widget) Init() { W.WInit() }
 func (W _cogentcore_org_core_core_Widget) NodeWalkDown(fun func(n tree.Node) bool) {
 	W.WNodeWalkDown(fun)
 }
@@ -871,12 +936,19 @@ func (W _cogentcore_org_core_core_Widget) Render()          { W.WRender() }
 func (W _cogentcore_org_core_core_Widget) RenderSource(op draw.Op) composer.Source {
 	return W.WRenderSource(op)
 }
-func (W _cogentcore_org_core_core_Widget) RenderWidget()                  { W.WRenderWidget() }
+func (W _cogentcore_org_core_core_Widget) RenderWidget() { W.WRenderWidget() }
+func (W _cogentcore_org_core_core_Widget) Search(find string, useCase bool) ([]textpos.Match, bool) {
+	return W.WSearch(find, useCase)
+}
+func (W _cogentcore_org_core_core_Widget) SelectMatch(matches []textpos.Match, index int, scroll bool, reset bool) {
+	W.WSelectMatch(matches, index, scroll, reset)
+}
 func (W _cogentcore_org_core_core_Widget) ShowContextMenu(e events.Event) { W.WShowContextMenu(e) }
 func (W _cogentcore_org_core_core_Widget) SizeDown(iter int) bool         { return W.WSizeDown(iter) }
 func (W _cogentcore_org_core_core_Widget) SizeFinal()                     { W.WSizeFinal() }
 func (W _cogentcore_org_core_core_Widget) SizeUp()                        { W.WSizeUp() }
 func (W _cogentcore_org_core_core_Widget) Style()                         { W.WStyle() }
+func (W _cogentcore_org_core_core_Widget) TextRunes() []rune              { return W.WTextRunes() }
 func (W _cogentcore_org_core_core_Widget) WidgetTooltip(pos image.Point) (string, image.Point) {
 	return W.WWidgetTooltip(pos)
 }

--- a/yaegicore/coresymbols/cogentcore_org-core-filetree.go
+++ b/yaegicore/coresymbols/cogentcore_org-core-filetree.go
@@ -8,6 +8,7 @@ import (
 	"cogentcore.org/core/events"
 	"cogentcore.org/core/filetree"
 	"cogentcore.org/core/system/composer"
+	"cogentcore.org/core/text/textpos"
 	"cogentcore.org/core/tree"
 	"golang.org/x/image/draw"
 	"image"
@@ -62,6 +63,7 @@ type _cogentcore_org_core_filetree_Filer struct {
 	WDragDrop         func(e events.Event)
 	WDropDeleteSource func(e events.Event)
 	WGetFileInfo      func() error
+	WHighlightMatches func(matches []textpos.Match) bool
 	WInit             func()
 	WMimeData         func(md *mimedata.Mimes)
 	WNodeWalkDown     func(fun func(n tree.Node) bool)
@@ -76,11 +78,14 @@ type _cogentcore_org_core_filetree_Filer struct {
 	WRender           func()
 	WRenderSource     func(op draw.Op) composer.Source
 	WRenderWidget     func()
+	WSearch           func(find string, useCase bool) ([]textpos.Match, bool)
+	WSelectMatch      func(matches []textpos.Match, index int, scroll bool, reset bool)
 	WShowContextMenu  func(e events.Event)
 	WSizeDown         func(iter int) bool
 	WSizeFinal        func()
 	WSizeUp           func()
 	WStyle            func()
+	WTextRunes        func() []rune
 	WWidgetTooltip    func(pos image.Point) (string, image.Point)
 }
 
@@ -105,8 +110,11 @@ func (W _cogentcore_org_core_filetree_Filer) Destroy()                        { 
 func (W _cogentcore_org_core_filetree_Filer) DragDrop(e events.Event)         { W.WDragDrop(e) }
 func (W _cogentcore_org_core_filetree_Filer) DropDeleteSource(e events.Event) { W.WDropDeleteSource(e) }
 func (W _cogentcore_org_core_filetree_Filer) GetFileInfo() error              { return W.WGetFileInfo() }
-func (W _cogentcore_org_core_filetree_Filer) Init()                           { W.WInit() }
-func (W _cogentcore_org_core_filetree_Filer) MimeData(md *mimedata.Mimes)     { W.WMimeData(md) }
+func (W _cogentcore_org_core_filetree_Filer) HighlightMatches(matches []textpos.Match) bool {
+	return W.WHighlightMatches(matches)
+}
+func (W _cogentcore_org_core_filetree_Filer) Init()                       { W.WInit() }
+func (W _cogentcore_org_core_filetree_Filer) MimeData(md *mimedata.Mimes) { W.WMimeData(md) }
 func (W _cogentcore_org_core_filetree_Filer) NodeWalkDown(fun func(n tree.Node) bool) {
 	W.WNodeWalkDown(fun)
 }
@@ -122,12 +130,19 @@ func (W _cogentcore_org_core_filetree_Filer) Render()          { W.WRender() }
 func (W _cogentcore_org_core_filetree_Filer) RenderSource(op draw.Op) composer.Source {
 	return W.WRenderSource(op)
 }
-func (W _cogentcore_org_core_filetree_Filer) RenderWidget()                  { W.WRenderWidget() }
+func (W _cogentcore_org_core_filetree_Filer) RenderWidget() { W.WRenderWidget() }
+func (W _cogentcore_org_core_filetree_Filer) Search(find string, useCase bool) ([]textpos.Match, bool) {
+	return W.WSearch(find, useCase)
+}
+func (W _cogentcore_org_core_filetree_Filer) SelectMatch(matches []textpos.Match, index int, scroll bool, reset bool) {
+	W.WSelectMatch(matches, index, scroll, reset)
+}
 func (W _cogentcore_org_core_filetree_Filer) ShowContextMenu(e events.Event) { W.WShowContextMenu(e) }
 func (W _cogentcore_org_core_filetree_Filer) SizeDown(iter int) bool         { return W.WSizeDown(iter) }
 func (W _cogentcore_org_core_filetree_Filer) SizeFinal()                     { W.WSizeFinal() }
 func (W _cogentcore_org_core_filetree_Filer) SizeUp()                        { W.WSizeUp() }
 func (W _cogentcore_org_core_filetree_Filer) Style()                         { W.WStyle() }
+func (W _cogentcore_org_core_filetree_Filer) TextRunes() []rune              { return W.WTextRunes() }
 func (W _cogentcore_org_core_filetree_Filer) WidgetTooltip(pos image.Point) (string, image.Point) {
 	return W.WWidgetTooltip(pos)
 }


### PR DESCRIPTION
This fixes #1548 #1644 #28 #1111 and mostly addresses #1325 

* full functional tabs support in content: add, delete, ctrl+click
* fixed the history logic, which is now per-tab
* Search fully supported in collection widgets (table, list, tree) and individual elements, with a Widget interface
* selection across multiple text elements

This fixes the main remaining missing features for content, and search is very long overdue.
