### PR TITLE
Fix canvas render on web target

### DIFF
--- a/paint/renderers/htmlcanvas/htmlcanvas.go
+++ b/paint/renderers/htmlcanvas/htmlcanvas.go
@@ -104,7 +104,7 @@ func (rs *Renderer) PopContext(pt *render.ContextPop) {
 }
 
 func (rs *Renderer) setTransform(ctx *render.Context) {
-	m := ctx.Transform
+	m := ctx.Cumulative
 	rs.ctx.Call("setTransform", m.XX, m.YX, m.XY, m.YY, m.X0, m.Y0)
 }
 

--- a/paint/renderers/htmlcanvas/path.go
+++ b/paint/renderers/htmlcanvas/path.go
@@ -57,7 +57,7 @@ func (rs *Renderer) RenderPath(pt *render.Path) {
 		rs.ctx.Call("fill", style.Fill.Rule.String())
 	}
 	if style.HasStroke() {
-		scale := math32.Sqrt(math32.Abs(pt.Context.Transform.Det()))
+		scale := math32.Sqrt(math32.Abs(pt.Context.Cumulative.Det()))
 		if scale != 1 {
 			// note: this is a hack to get the effect of [ppath.VectorEffectNonScalingStroke]
 			stk := style.Stroke


### PR DESCRIPTION
Transforming the normalized coordinates using the `ctx.Cumulative` matrix will fix the issue.

## Before

<img width="1441" height="914" alt="Before" src="https://github.com/user-attachments/assets/69e31313-ce33-40a0-8b05-1a9ef4515793" />

## After

<img width="1446" height="930" alt="After" src="https://github.com/user-attachments/assets/1257655d-e303-4c3e-9ca2-0caf49c7879e" />

Fixes #1671 