### PR TITLE
fix(security): 2 improvements across 2 files

### DIFF
--- a/base/iox/imagex/base64.go
+++ b/base/iox/imagex/base64.go
@@ -47,7 +47,7 @@ func Base64SplitLines(b []byte) []byte {
 
 // FromBase64 returns image from Base64-encoded bytes
 func FromBase64(eb []byte) (image.Image, Formats, error) {
-	if eb[76] == ' ' {
+	if len(eb) > 76 && eb[76] == ' ' {
 		eb = bytes.ReplaceAll(eb, []byte(" "), []byte("\n"))
 	}
 	db := make([]byte, base64.StdEncoding.DecodedLen(len(eb)))

--- a/cmd/changed.go
+++ b/cmd/changed.go
@@ -23,6 +23,7 @@ import (
 func Changed(c *config.Config) error { //types:add
 	wg := sync.WaitGroup{}
 	errs := []error{}
+	errMu := sync.Mutex{}
 	fs.WalkDir(os.DirFS("."), ".", func(path string, d fs.DirEntry, err error) error {
 		wg.Add(1)
 		go func() {
@@ -33,7 +34,9 @@ func Changed(c *config.Config) error { //types:add
 			dir := filepath.Dir(path)
 			out, err := exec.Major().SetDir(dir).Output("git", "diff")
 			if err != nil {
+				errMu.Lock()
 				errs = append(errs, fmt.Errorf("error getting diff of %q: %w", dir, err))
+				errMu.Unlock()
 				return
 			}
 			if out != "" { // if we have a diff, we have been changed
@@ -43,7 +46,9 @@ func Changed(c *config.Config) error { //types:add
 			// if we don't have a diff, we also check to make sure we aren't ahead of the remote
 			out, err = exec.Minor().SetDir(dir).Output("git", "status")
 			if err != nil {
+				errMu.Lock()
 				errs = append(errs, fmt.Errorf("error getting status of %q: %w", dir, err))
+				errMu.Unlock()
 				return
 			}
 			if strings.Contains(out, "Your branch is ahead") { // if we are ahead, we have been changed


### PR DESCRIPTION
## Summary

fix(security): 2 improvements across 2 files

## Problem

**Severity**: `Medium` | **File**: `base/iox/imagex/base64.go:L43`

`FromBase64` indexes `eb[76]` without checking input length first. If attacker-controlled or malformed input shorter than 77 bytes is passed, this will panic and can be used for denial of service.

## Solution

Guard access with a length check before indexing (e.g., `if len(eb) > 76 && eb[76] == ' ' { ... }`). Also consider robust whitespace normalization that does not rely on fixed offsets.

## Changes

- `base/iox/imagex/base64.go` (modified)
- `cmd/changed.go` (modified)