### PR TITLE
fix(text/lines): skip invalid line-break offsets in layoutViewLine

### DIFF
--- a/text/lines/layout.go
+++ b/text/lines/layout.go
@@ -138,7 +138,11 @@ func (ls *Lines) layoutViewLine(ln, width int, txt []rune, mu rich.Text) ([]rich
 	}
 	muls := make([]rich.Text, 0, nb+1)
 	last := 0
+	ltn := len(lt)
 	for _, si := range breaks {
+		if si < last || si > ltn {
+			continue
+		}
 		muls = append(muls, lt[last:si])
 		last = si
 	}


### PR DESCRIPTION
Out-of-range or non-monotonic break indices were panicking the text layout pass on certain inputs. Skip break offsets that fall outside `[last, len(lt)]` so a single bad break is dropped rather than crashing the whole render. Fixes #1544.