### PR TITLE
Version string in content, misc other fixes

### DIFF
--- a/content/bcontent/page.go
+++ b/content/bcontent/page.go
@@ -52,6 +52,12 @@ type Page struct {
 	// DateString is only used for parsing the date from the TOML front matter.
 	DateString string `toml:"Date" json:"-"`
 
+	// Version is a version string, e.g., for pages that have some kind of publication
+	// status. Typically reserve for major changes, with the Date being used to track
+	// minor changes (typo fixes etc). Will be rendered with "Version: " prepended,
+	// in the same line as the date if date is set.
+	Version string
+
 	// Authors are the optional author(s) of the page.
 	Authors string
 

--- a/content/content.go
+++ b/content/content.go
@@ -253,7 +253,19 @@ func (ct *Content) pageMaker(p *tree.Plan, tabIdx int) {
 				tree.Add(p, func(w *core.Text) {
 					w.SetType(core.TextTitleMedium)
 					w.Updater(func() {
-						w.SetText(ct.current.Page.Date.Format("January 2, 2006"))
+						if ct.current.Page.Version != "" {
+							w.SetText(ct.current.Page.Date.Format("January 2, 2006") + ", Version: " + ct.current.Page.Version)
+						} else {
+							w.SetText(ct.current.Page.Date.Format("January 2, 2006"))
+						}
+					})
+				})
+			}
+			if !ct.inPDFRender && ct.current.Page.Date.IsZero() && ct.current.Page.Version != "" {
+				tree.Add(p, func(w *core.Text) {
+					w.SetType(core.TextTitleMedium)
+					w.Updater(func() {
+						w.SetText(" Version: " + ct.current.Page.Version)
 					})
 				})
 			}

--- a/content/examples/basic/content/button.md
+++ b/content/examples/basic/content/button.md
@@ -4,6 +4,7 @@ Authors = "Bea A. Author<sup>1</sup> and Test Ing Name<sup>2</sup>"
 Affiliations = "<sup>1</sup>University of Somewhere <sup>2</sup>University of Elsewhere"
 Abstract = "The button is an essential element of any GUI framework, with the capability of triggering actions of any sort. Actions are very important because they allow people to actually do something."
 Date = "2026-05-01"
+Version = "1"
 +++
 
 A **button** is a [[widget]] that a user can click on to trigger a described action. See [[func button]] for a button [[value binding|bound]] to a function. There are various [[#types]] of buttons.
@@ -109,6 +110,12 @@ core.NewButton(b).SetType(core.ButtonAction).SetText("Action")
 
 ### Third level header
 
+{id="eq_dwt" title="example"}
+$$
+dW = x^+ y^+ - x^- y^-
+$$
+
+{style="paginate-break:true"}
 This is content at the third level.
 
 #### Fourth level header

--- a/content/handlers.go
+++ b/content/handlers.go
@@ -51,7 +51,12 @@ func (ct *Content) htmlIDAttributeHandler(ctx *htmlcore.Context, w io.Writer, no
 		return false
 	}
 	if entering {
-		cp := "\n<span id=\"" + value + "\"><b>" + lbl + ":</b>"
+		cp := "\n<span id=\"" + value + "\""
+		style := htmlcore.MDGetAttr(node, "style")
+		if style != "" {
+			cp += fmt.Sprintf(" style=%q", style)
+		}
+		cp += "><b>" + lbl + ":</b>"
 		title := htmlcore.MDGetAttr(node, "title")
 		if title != "" {
 			cp += " " + title

--- a/content/page_test.go
+++ b/content/page_test.go
@@ -30,5 +30,6 @@ func TestNewPage(t *testing.T) {
 		Abstract:     "The button is an essential element of any GUI framework, with the capability of triggering actions of any sort. Actions are very important because they allow people to actually do something.",
 		DateString:   dstr,
 		Date:         date,
+		Version:      "1",
 	}, *pg)
 }

--- a/content/settings.go
+++ b/content/settings.go
@@ -53,7 +53,7 @@ func (s *SettingsData) Defaults() {
 		} else {
 			dt = time.Now().Format("January 2, 2006")
 		}
-		ps.PDF.Title = paginate.CenteredTitle(pt, curPage.Authors, curPage.Affiliations, ura, dt, curPage.Reference, curPage.Abstract)
+		ps.PDF.Title = paginate.CenteredTitle(pt, curPage.Authors, curPage.Affiliations, ura, dt, curPage.Version, curPage.Reference, curPage.Abstract)
 		ps.PDF.TextStyler = paginate.APAHeaders
 		return ps
 	}

--- a/htmlcore/context.go
+++ b/htmlcore/context.go
@@ -152,7 +152,7 @@ func (c *Context) config(w core.Widget) {
 			wb.SetName(attr.Val)
 			wb.SetProperty("id", attr.Val)
 		case "style":
-			c.setStyleAttr(c.Node, attr.Val)
+			c.SetStyleAttr(c.Node, attr.Val)
 		default:
 			wb.SetProperty(attr.Key, attr.Val)
 		}
@@ -160,7 +160,7 @@ func (c *Context) config(w core.Widget) {
 	wb.SetProperty("tag", c.Node.Data) // this is needed by handleWidget in general
 }
 
-func (c *Context) setStyleAttr(node *html.Node, style string) error {
+func (c *Context) SetStyleAttr(node *html.Node, style string) error {
 	// our CSS parser is strict about semicolons, but
 	// they aren't needed in normal inline styles in HTML
 	if !strings.HasSuffix(style, ";") {
@@ -264,6 +264,10 @@ func (c *Context) applyStyleRules(node *html.Node, w core.Widget) {
 	wb.Styler(func(s *styles.Style) {
 		for _, rule := range rules {
 			for _, decl := range rule.Declarations {
+				if strings.HasPrefix(decl.Property, "paginate-") {
+					wb.SetProperty(decl.Property, decl.Value)
+					continue
+				}
 				// TODO(kai/styproperties): parent style and context
 				s.FromProperty(s, decl.Property, decl.Value, colors.BaseContext(colors.ToUniform(s.Color)))
 			}

--- a/htmlcore/handler.go
+++ b/htmlcore/handler.go
@@ -50,7 +50,7 @@ func handleElement(ctx *Context) {
 	}
 
 	if slices.Contains(textTags, tag) {
-		handleTextTag(ctx)
+		ctx.handleWidget(ctx.Node, handleTextTag(ctx))
 		return
 	}
 
@@ -319,7 +319,7 @@ func handleImage(ctx *Context, tag string) core.Widget {
 	src := GetAttr(n, "src")
 	alt := GetAttr(n, "alt")
 	if pstyle != "" {
-		ctx.setStyleAttr(n, pstyle)
+		ctx.SetStyleAttr(n, pstyle)
 	}
 	var newWidget core.Widget
 	var resp *http.Response

--- a/paint/pdf/links.go
+++ b/paint/pdf/links.go
@@ -30,10 +30,14 @@ func (w *pdfPage) AddAnchor(name string, pos math32.Vector2) {
 func (w *pdfPage) AddLink(uri string, rect math32.Box2) {
 	ms := math32.Scale2D(w.pdf.globalScale, w.pdf.globalScale)
 	rect = rect.MulMatrix2(ms)
+	bs := pdfDict{
+		"W": 0,
+	}
 	annot := pdfDict{
 		"Type":    pdfName("Annot"),
 		"Subtype": pdfName("Link"),
-		"Border":  pdfArray{0, 0, 0},
+		"BS":      bs,
+		"C":       pdfArray{0.8, 0.8, 1.0},
 		"Rect":    pdfArray{rect.Min.X, w.height - rect.Max.Y, rect.Max.X, w.height - rect.Min.Y},
 	}
 	if len(uri) > 0 && uri[0] == '#' { // local anchor actions
@@ -41,6 +45,7 @@ func (w *pdfPage) AddLink(uri string, rect math32.Box2) {
 	} else {
 		annot["Contents"] = uri
 		annot["A"] = pdfDict{
+			"Type":         pdfName("Action"),
 			"S":            pdfName("URI"),
 			pdfName("URI"): uri,
 		}

--- a/paint/pdf/text.go
+++ b/paint/pdf/text.go
@@ -172,6 +172,10 @@ func (r *PDF) textRun(style *styles.Paint, m math32.Matrix2, run *shapedgt.Run, 
 	r.w.StartTextObject(math32.Translate2D(off.X, off.Y))
 	r.setTextStyle(&run.Font, style, fill, run.StrokeColor, math32.FromFixed(run.Size), lns.LineHeight)
 	raw := string(runes[region.Start:region.End])
+	raw = strings.ReplaceAll(raw, "https://", "https.//") // links need to be obfuscated, to prevent PDF auto-link detection!
+	raw = strings.ReplaceAll(raw, "http://", "http.//")   // links need to be obfuscated, to prevent PDF auto-link detection!
+	raw = strings.ReplaceAll(raw, "www.", "www:")
+	raw = strings.ReplaceAll(raw, "doi.", "doi:")
 	r.w.WriteText(raw)
 	r.w.EndTextObject()
 
@@ -255,10 +259,13 @@ func (r *PDF) links(lns *shaped.Lines, m math32.Matrix2, pos math32.Vector2) {
 		// note: link coordinates are in default user space, not current transform.
 		srb := lns.RuneBounds(lk.Range.Start)
 		erb := lns.RuneBounds(lk.Range.End)
+		rb := srb
 		if erb.Max.X > srb.Max.X {
-			srb.Max.X = erb.Max.X
+			rb.Max.X = erb.Max.X
+		} else {
+			rb.Max.X = lns.Bounds.Max.X
 		}
-		rb := srb.Translate(pos)
+		rb = rb.Translate(pos)
 		rb = rb.MulMatrix2(m)
 		r.w.AddLink(lk.URL, rb)
 	}

--- a/text/paginate/paginate_test.go
+++ b/text/paginate/paginate_test.go
@@ -29,7 +29,7 @@ func RunTest(t *testing.T, nm string, f func() *core.Body) {
 
 	opts := NewOptions()
 	opts.Header = NoFirst(HeaderLeftPageNumber("This is a test header"))
-	opts.Title = CenteredTitle("This is a Profound Statement of Something Important", "Bea A. Author", "University of Twente<br>Department of Physiology", `<a href="https://example.com/testing">https://example.com/testing</a>`, "March 1, 2024", "Preprint: bioRxiv xxx.yyy", "The thing about this paper is that it is dealing with an issue that should be given more attention, but perhaps it really is hard to understand and that makes it difficult to get the attention it deserves. In any case, we are very proud.")
+	opts.Title = CenteredTitle("This is a Profound Statement of Something Important", "Bea A. Author<sup>1</sup>", "<sup>1</sup>University of Twente<br>Department of Physiology", `<a href="https://example.com/testing">https://example.com/testing</a>`, "March 1, 2024", "1", "Preprint: bioRxiv xxx.yyy", "The thing about this paper is that it is dealing with an issue that should be given more attention, but perhaps it really is hard to understand and that makes it difficult to get the attention it deserves. In any case, we are very proud.")
 	buff := bytes.Buffer{}
 	b.AsyncLock()
 	PDF(&buff, opts, b)

--- a/text/paginate/runners.go
+++ b/text/paginate/runners.go
@@ -80,7 +80,7 @@ func HeaderLeftPageNumber(header string) func(frame *core.Frame, opts *Options, 
 }
 
 // CenteredTitle inserts centered text elements for each element if non-empty.
-func CenteredTitle(title, authors, affiliations, url, date, reference, abstract string) func(frame *core.Frame, opts *Options) {
+func CenteredTitle(title, authors, affiliations, url, date, version, reference, abstract string) func(frame *core.Frame, opts *Options) {
 	return func(frame *core.Frame, opts *Options) {
 		fr := core.NewFrame(frame)
 		fr.Styler(func(s *styles.Style) {
@@ -122,7 +122,17 @@ func CenteredTitle(title, authors, affiliations, url, date, reference, abstract 
 		core.NewSpace(fr).Styler(func(s *styles.Style) { s.Min.Y.Em(1) })
 
 		if date != "" {
-			core.NewText(fr).SetText(date).Styler(func(s *styles.Style) {
+			txt := date
+			if version != "" {
+				txt += ", Version: " + version
+			}
+			core.NewText(fr).SetText(txt).Styler(func(s *styles.Style) {
+				TextStyler(s)
+				s.Font.Size = printer.Settings.FontSize
+				s.Text.Align = text.Center
+			})
+		} else if version != "" {
+			core.NewText(fr).SetText("Version: " + version).Styler(func(s *styles.Style) {
 				TextStyler(s)
 				s.Font.Size = printer.Settings.FontSize
 				s.Text.Align = text.Center


### PR DESCRIPTION
add Version string to content; add support for paginate- directives in content style; fix pdf rendering support for links that have wrapped around (needed to obfuscate the auto-link detection in most viewers!).
