### PR TITLE
Hrimage: support high-resolution image rendering for renderers in PDF, SVG

### DIFF
--- a/core/icon.go
+++ b/core/icon.go
@@ -103,5 +103,5 @@ func (ic *Icon) Render() {
 	}
 	r := ic.Geom.ContentBBox
 	sp := ic.Geom.ScrollOffset()
-	ic.Scene.Painter.DrawImage(ic.pixels, r, sp, draw.Over)
+	ic.Scene.Painter.DrawImage(ic.pixels, nil, r, sp, draw.Over)
 }

--- a/core/image.go
+++ b/core/image.go
@@ -128,7 +128,7 @@ func (im *Image) Render() {
 		}
 		im.prevRenderImage = rimg
 	}
-	pim := im.Scene.Painter.DrawImage(rimg, r, sp, draw.Over)
+	pim := im.Scene.Painter.DrawImage(rimg, im.Image, r, sp, draw.Over)
 	if id, ok := im.Properties["id"]; ok {
 		pim.Anchor = id.(string)
 	}

--- a/core/image.go
+++ b/core/image.go
@@ -83,7 +83,14 @@ func (im *Image) SizeUp() {
 	if im.Image != nil {
 		sz := &im.Geom.Size
 		obj := math32.FromPoint(im.Image.Bounds().Size())
-		osz := styles.ObjectSizeFromFit(im.Styles.ObjectFit, obj, sz.Actual.Content)
+		csz := sz.Actual.Content
+		// if only one min size is specified, then allow the other to expand
+		if im.Styles.Min.Y.Value != 0 && im.Styles.Min.X.Value == 0 {
+			csz.X = obj.X
+		} else if im.Styles.Min.X.Value != 0 && im.Styles.Min.Y.Value == 0 {
+			csz.Y = obj.Y
+		}
+		osz := styles.ObjectSizeFromFit(im.Styles.ObjectFit, obj, csz)
 		sz.Actual.Content = osz
 		sz.SetTotalFromContent(&sz.Actual)
 	}

--- a/core/image.go
+++ b/core/image.go
@@ -13,7 +13,6 @@ import (
 	"cogentcore.org/core/math32"
 	"cogentcore.org/core/paint/renderers/rasterx"
 	"cogentcore.org/core/styles"
-	"cogentcore.org/core/styles/units"
 	"cogentcore.org/core/system"
 	"cogentcore.org/core/tree"
 	"golang.org/x/image/draw"
@@ -48,13 +47,6 @@ func (im *Image) Init() {
 	im.WidgetBase.Init()
 	im.Styler(func(s *styles.Style) {
 		s.ObjectFit = styles.FitContain
-		if im.Image != nil {
-			sz := im.Image.Bounds().Size()
-			s.Min.X.SetCustom(func(uc *units.Context) float32 {
-				return min(uc.Dp(float32(sz.X)), uc.Pw(95))
-			})
-			s.Min.Y.Dp(float32(sz.Y))
-		}
 	})
 }
 
@@ -88,6 +80,19 @@ func (im *Image) SizeUp() {
 		if im.Styles.Min.Y.Value != 0 && im.Styles.Min.X.Value == 0 {
 			csz.X = obj.X
 		} else if im.Styles.Min.X.Value != 0 && im.Styles.Min.Y.Value == 0 {
+			csz.Y = obj.Y
+		} else if im.Styles.Min.X.Value == 0 && im.Styles.Min.Y.Value == 0 {
+			pwd := float32(0)
+			pwb := im.parentWidget()
+			if pwb != nil {
+				psz := pwb.Geom.Size.Alloc.Content.Sub(pwb.Geom.Size.InnerSpace)
+				pwd = 0.95 * psz.X
+			}
+			if pwd > 0 {
+				csz.X = min(obj.X, pwd)
+			} else {
+				csz.X = obj.X
+			}
 			csz.Y = obj.Y
 		}
 		osz := styles.ObjectSizeFromFit(im.Styles.ObjectFit, obj, csz)

--- a/core/sprite.go
+++ b/core/sprite.go
@@ -132,7 +132,7 @@ func NewImageSprite(name string, pos image.Point, img image.Image) *Sprite {
 	sp.Properties["image"] = img
 	sp.EventBBox = img.Bounds().Add(pos)
 	sp.Draw = func(pc *paint.Painter) {
-		pc.DrawImage(img, sp.EventBBox, image.Point{}, draw.Over)
+		pc.DrawImage(img, nil, sp.EventBBox, image.Point{}, draw.Over)
 	}
 	return sp
 }

--- a/core/svg.go
+++ b/core/svg.go
@@ -167,7 +167,7 @@ func (sv *SVG) Render() {
 	}
 	r := sv.Geom.ContentBBox
 	sp := sv.Geom.ScrollOffset()
-	sv.Scene.Painter.DrawImage(sv.image, r, sp, draw.Over)
+	sv.Scene.Painter.DrawImage(sv.image, nil, r, sp, draw.Over)
 }
 
 func (sv *SVG) MakeToolbar(p *tree.Plan) {

--- a/paint/background_test.go
+++ b/paint/background_test.go
@@ -65,7 +65,7 @@ func TestObjectFit(t *testing.T) {
 		test := func(of styles.ObjectFits, pos math32.Vector2) {
 			st.ObjectFit = of
 			fitimg := st.ResizeImage(img, box)
-			pc.DrawImageAnchored(fitimg, pos.X, pos.Y, 0, 0)
+			pc.DrawImageAnchored(fitimg, img, pos.X, pos.Y, 0, 0)
 			// trgsz := styles.ObjectSizeFromFit(of, obj, box)
 			// fmt.Println(of, trgsz)
 		}

--- a/paint/paint_test.go
+++ b/paint/paint_test.go
@@ -25,7 +25,9 @@ import (
 	"cogentcore.org/core/text/rich"
 	"cogentcore.org/core/text/shaped"
 	"cogentcore.org/core/text/text"
+	"github.com/anthonynsimon/bild/transform"
 	"github.com/stretchr/testify/assert"
+	"golang.org/x/image/draw"
 )
 
 // RunTest makes a rendering state, paint, and image with the given size, calls the given
@@ -241,6 +243,16 @@ func TestPaintFill(t *testing.T) {
 		pc.Fill.Color = nil
 		pc.Stroke.Color = colors.Uniform(colors.Orange)
 		pc.Rectangle(50, 25, 150, 200)
+		pc.Draw()
+	})
+}
+
+func TestHighResImage(t *testing.T) {
+	img, _, err := imagex.Open("testdata/test.png")
+	smimg := transform.Resize(img, 60, 60, transform.Linear)
+	assert.NoError(t, err)
+	RunTest(t, "highres-image", 60, 60, func(pc *Painter) {
+		pc.DrawImage(smimg, img, smimg.Bounds(), image.Point{0, 0}, draw.Src)
 		pc.Draw()
 	})
 }

--- a/paint/painter.go
+++ b/paint/painter.go
@@ -461,7 +461,7 @@ func (pc *Painter) DrawBox(pos, size math32.Vector2, img image.Image, op draw.Op
 	} else {
 		img = gradient.ApplyOpacity(img, pc.Fill.Opacity)
 	}
-	pc.Render.Add(pimage.NewDraw(b, img, b.Min, op))
+	pc.Render.Add(pimage.NewDraw(b, img, nil, b.Min, op))
 }
 
 // BlurBox blurs the given already drawn region with the given blur radius.
@@ -507,37 +507,40 @@ func (pc *Painter) SetPixel(x, y int) {
 }
 
 // DrawImage draws the given image at the specified starting point,
-// using the bounds of the source image in rectangle rect, using
-// the given draw operration: Over = overlay (alpha blend with destination)
+// using the bounds of the source image in rectangle rect. orig = original
+// source image, which is used for high-resolution rendering if higher res.
+// Uses the given draw operration: Over = overlay (alpha blend with destination)
 // Src = copy source directly, overwriting destination pixels.
-func (pc *Painter) DrawImage(src image.Image, rect image.Rectangle, srcStart image.Point, op draw.Op) *pimage.Params {
-	pim := pimage.NewDraw(rect, src, srcStart, op)
+func (pc *Painter) DrawImage(src, orig image.Image, rect image.Rectangle, srcStart image.Point, op draw.Op) *pimage.Params {
+	pim := pimage.NewDraw(rect, src, orig, srcStart, op)
 	pc.Render.Add(pim)
 	return pim
 }
 
 // DrawImageAnchored draws the specified image at the specified anchor point.
+// orig = original source image, which is used for high-resolution rendering.
 // The anchor point is x - w * ax, y - h * ay, where w, h is the size of the
 // image. Use ax=0.5, ay=0.5 to center the image at the specified point.
-func (pc *Painter) DrawImageAnchored(src image.Image, x, y, ax, ay float32) *pimage.Params {
+func (pc *Painter) DrawImageAnchored(src, orig image.Image, x, y, ax, ay float32) *pimage.Params {
 	s := src.Bounds().Size()
 	x -= ax * float32(s.X)
 	y -= ay * float32(s.Y)
 	m := pc.Cumulative().Translate(x, y)
 	var pim *pimage.Params
 	if pc.Mask == nil {
-		pim = pimage.NewTransform(m, src.Bounds(), src, draw.Over)
+		pim = pimage.NewTransform(m, src.Bounds(), src, orig, draw.Over)
 	} else {
-		pim = pimage.NewTransformMask(m, src.Bounds(), src, draw.Over, pc.Mask, image.Point{})
+		pim = pimage.NewTransformMask(m, src.Bounds(), src, orig, draw.Over, pc.Mask, image.Point{})
 	}
 	pc.Render.Add(pim)
 	return pim
 }
 
 // DrawImageScaled draws the specified image starting at given upper-left point,
+// orig = original source image, which is used for high-resolution rendering,
 // such that the size of the image is rendered as specified by w, h parameters
 // (an additional scaling is applied to the transform matrix used in rendering)
-func (pc *Painter) DrawImageScaled(src image.Image, x, y, w, h float32) *pimage.Params {
+func (pc *Painter) DrawImageScaled(src, orig image.Image, x, y, w, h float32) *pimage.Params {
 	s := src.Bounds().Size()
 	isz := math32.FromPoint(s)
 	isc := math32.Vec2(w, h).Div(isz)
@@ -545,9 +548,9 @@ func (pc *Painter) DrawImageScaled(src image.Image, x, y, w, h float32) *pimage.
 	m := pc.Cumulative().Translate(x, y).Scale(isc.X, isc.Y)
 	var pim *pimage.Params
 	if pc.Mask == nil {
-		pim = pimage.NewTransform(m, src.Bounds(), src, draw.Over)
+		pim = pimage.NewTransform(m, src.Bounds(), src, orig, draw.Over)
 	} else {
-		pim = pimage.NewTransformMask(m, src.Bounds(), src, draw.Over, pc.Mask, image.Point{})
+		pim = pimage.NewTransformMask(m, src.Bounds(), src, orig, draw.Over, pc.Mask, image.Point{})
 	}
 	pc.Render.Add(pim)
 	return pim

--- a/paint/pimage/pimage.go
+++ b/paint/pimage/pimage.go
@@ -54,6 +54,10 @@ type Params struct {
 	// Source to draw.
 	Source image.Image
 
+	// Original is the original source image, which is used for
+	// high-resolution renderers (e.g., PDF).
+	Original image.Image
+
 	// Mask, used if non-nil.
 	Mask image.Image
 
@@ -86,41 +90,41 @@ func NewClear(src image.Image, sp image.Point, op draw.Op) *Params {
 
 // NewDraw returns a new Draw operation with given parameters.
 // Does nothing if rect is empty.
-func NewDraw(rect image.Rectangle, src image.Image, sp image.Point, op draw.Op) *Params {
+func NewDraw(rect image.Rectangle, src, orig image.Image, sp image.Point, op draw.Op) *Params {
 	if rect == (image.Rectangle{}) {
 		return nil
 	}
-	pr := &Params{Cmd: Draw, Rect: rect, Source: imagex.WrapJS(src), SourcePos: sp, Op: op}
+	pr := &Params{Cmd: Draw, Rect: rect, Source: imagex.WrapJS(src), Original: imagex.WrapJS(orig), SourcePos: sp, Op: op}
 	return pr
 }
 
 // NewDrawMask returns a new DrawMask operation with given parameters.
 // Does nothing if rect is empty.
-func NewDrawMask(rect image.Rectangle, src image.Image, sp image.Point, op draw.Op, mask image.Image, mp image.Point) *Params {
+func NewDrawMask(rect image.Rectangle, src, orig image.Image, sp image.Point, op draw.Op, mask image.Image, mp image.Point) *Params {
 	if rect == (image.Rectangle{}) {
 		return nil
 	}
-	pr := &Params{Cmd: Draw, Rect: rect, Source: imagex.WrapJS(src), SourcePos: sp, Op: op, Mask: imagex.WrapJS(mask), MaskPos: mp}
+	pr := &Params{Cmd: Draw, Rect: rect, Source: imagex.WrapJS(src), Original: imagex.WrapJS(orig), SourcePos: sp, Op: op, Mask: imagex.WrapJS(mask), MaskPos: mp}
 	return pr
 }
 
 // NewTransform returns a new Transform operation with given parameters.
 // Does nothing if rect is empty.
-func NewTransform(m math32.Matrix2, rect image.Rectangle, src image.Image, op draw.Op) *Params {
+func NewTransform(m math32.Matrix2, rect image.Rectangle, src, orig image.Image, op draw.Op) *Params {
 	if rect == (image.Rectangle{}) {
 		return nil
 	}
-	pr := &Params{Cmd: Transform, Transform: m, Rect: rect, Source: imagex.WrapJS(src), Op: op}
+	pr := &Params{Cmd: Transform, Transform: m, Rect: rect, Source: imagex.WrapJS(src), Original: imagex.WrapJS(orig), Op: op}
 	return pr
 }
 
 // NewTransformMask returns a new Transform Mask operation with given parameters.
 // Does nothing if rect is empty.
-func NewTransformMask(m math32.Matrix2, rect image.Rectangle, src image.Image, op draw.Op, mask image.Image, mp image.Point) *Params {
+func NewTransformMask(m math32.Matrix2, rect image.Rectangle, src, orig image.Image, op draw.Op, mask image.Image, mp image.Point) *Params {
 	if rect == (image.Rectangle{}) {
 		return nil
 	}
-	pr := &Params{Cmd: Transform, Transform: m, Rect: rect, Source: imagex.WrapJS(src), Op: op, Mask: imagex.WrapJS(mask), MaskPos: mp}
+	pr := &Params{Cmd: Transform, Transform: m, Rect: rect, Source: imagex.WrapJS(src), Original: imagex.WrapJS(orig), Op: op, Mask: imagex.WrapJS(mask), MaskPos: mp}
 	return pr
 }
 
@@ -141,6 +145,7 @@ func NewSetPixel(at image.Point, clr image.Image) *Params {
 }
 
 // Render performs the image operation on given destination image.
+// This uses the native Go image package draw function.
 func (pr *Params) Render(dest *image.RGBA) {
 	switch pr.Cmd {
 	case Draw:

--- a/paint/pimage/pimage.go
+++ b/paint/pimage/pimage.go
@@ -94,7 +94,7 @@ func NewDraw(rect image.Rectangle, src, orig image.Image, sp image.Point, op dra
 	if rect == (image.Rectangle{}) {
 		return nil
 	}
-	pr := &Params{Cmd: Draw, Rect: rect, Source: imagex.WrapJS(src), Original: imagex.WrapJS(orig), SourcePos: sp, Op: op}
+	pr := &Params{Cmd: Draw, Rect: rect, Source: imagex.WrapJS(src), Original: orig, SourcePos: sp, Op: op}
 	return pr
 }
 
@@ -104,7 +104,7 @@ func NewDrawMask(rect image.Rectangle, src, orig image.Image, sp image.Point, op
 	if rect == (image.Rectangle{}) {
 		return nil
 	}
-	pr := &Params{Cmd: Draw, Rect: rect, Source: imagex.WrapJS(src), Original: imagex.WrapJS(orig), SourcePos: sp, Op: op, Mask: imagex.WrapJS(mask), MaskPos: mp}
+	pr := &Params{Cmd: Draw, Rect: rect, Source: imagex.WrapJS(src), Original: orig, SourcePos: sp, Op: op, Mask: imagex.WrapJS(mask), MaskPos: mp}
 	return pr
 }
 
@@ -114,7 +114,7 @@ func NewTransform(m math32.Matrix2, rect image.Rectangle, src, orig image.Image,
 	if rect == (image.Rectangle{}) {
 		return nil
 	}
-	pr := &Params{Cmd: Transform, Transform: m, Rect: rect, Source: imagex.WrapJS(src), Original: imagex.WrapJS(orig), Op: op}
+	pr := &Params{Cmd: Transform, Transform: m, Rect: rect, Source: imagex.WrapJS(src), Original: orig, Op: op}
 	return pr
 }
 
@@ -124,7 +124,7 @@ func NewTransformMask(m math32.Matrix2, rect image.Rectangle, src, orig image.Im
 	if rect == (image.Rectangle{}) {
 		return nil
 	}
-	pr := &Params{Cmd: Transform, Transform: m, Rect: rect, Source: imagex.WrapJS(src), Original: imagex.WrapJS(orig), Op: op, Mask: imagex.WrapJS(mask), MaskPos: mp}
+	pr := &Params{Cmd: Transform, Transform: m, Rect: rect, Source: imagex.WrapJS(src), Original: orig, Op: op, Mask: imagex.WrapJS(mask), MaskPos: mp}
 	return pr
 }
 

--- a/paint/renderers/pdfrender/pdfrender.go
+++ b/paint/renderers/pdfrender/pdfrender.go
@@ -171,10 +171,16 @@ func (rs *Renderer) RenderImage(pr *pimage.Params) {
 		// todo: handle:
 		return
 	}
-	// uorig := imagex.Unwrap(pr.Original)
 
-	// sz := pr.Rect.Size()
 	m := math32.Translate2D(float32(pr.Rect.Min.X), float32(pr.Rect.Min.Y))
-	rs.PDF.Image(usrc, m)
-	// simg.Pos = math32.FromPoint(pr.Rect.Min)
+	rimg := usrc
+	if pr.Original != nil {
+		uorig := imagex.Unwrap(pr.Original)
+		sc := float32(uorig.Bounds().Size().X) / float32(usrc.Bounds().Size().X)
+		if sc > 1.2 {
+			rimg = uorig
+			m = m.Scale(1.0/sc, float32(usrc.Bounds().Size().Y)/float32(uorig.Bounds().Size().Y))
+		}
+	}
+	rs.PDF.Image(rimg, m)
 }

--- a/paint/renderers/pdfrender/pdfrender.go
+++ b/paint/renderers/pdfrender/pdfrender.go
@@ -171,6 +171,7 @@ func (rs *Renderer) RenderImage(pr *pimage.Params) {
 		// todo: handle:
 		return
 	}
+	// uorig := imagex.Unwrap(pr.Original)
 
 	// sz := pr.Rect.Size()
 	m := math32.Translate2D(float32(pr.Rect.Min.X), float32(pr.Rect.Min.Y))

--- a/paint/renderers/pdfrender/pdfrender.go
+++ b/paint/renderers/pdfrender/pdfrender.go
@@ -8,8 +8,10 @@ import (
 	"bytes"
 	"image"
 	"io"
+	"reflect"
 
 	"cogentcore.org/core/base/iox/imagex"
+	"cogentcore.org/core/base/reflectx"
 	"cogentcore.org/core/base/stack"
 	"cogentcore.org/core/colors/gradient"
 	"cogentcore.org/core/math32"
@@ -176,10 +178,12 @@ func (rs *Renderer) RenderImage(pr *pimage.Params) {
 	rimg := usrc
 	if pr.Original != nil {
 		uorig := imagex.Unwrap(pr.Original)
-		sc := float32(uorig.Bounds().Size().X) / float32(usrc.Bounds().Size().X)
-		if sc > 1.2 {
-			rimg = uorig
-			m = m.Scale(1.0/sc, float32(usrc.Bounds().Size().Y)/float32(uorig.Bounds().Size().Y))
+		if !reflectx.IsNil(reflect.ValueOf(uorig)) {
+			sc := float32(uorig.Bounds().Size().X) / float32(usrc.Bounds().Size().X)
+			if sc > 1.2 {
+				rimg = uorig
+				m = m.Scale(1.0/sc, float32(usrc.Bounds().Size().Y)/float32(uorig.Bounds().Size().Y))
+			}
 		}
 	}
 	rs.PDF.Image(rimg, m)

--- a/paint/renderers/svgrender/svgrender.go
+++ b/paint/renderers/svgrender/svgrender.go
@@ -6,9 +6,9 @@ package svgrender
 
 import (
 	"bytes"
-	"fmt"
 	"image"
 	"maps"
+	"reflect"
 
 	"cogentcore.org/core/base/iox/imagex"
 	"cogentcore.org/core/base/reflectx"
@@ -207,10 +207,11 @@ func (rs *Renderer) RenderImage(pr *pimage.Params) {
 	rimg := usrc
 	if pr.Original != nil {
 		uorig := imagex.Unwrap(pr.Original)
-		sc := float32(uorig.Bounds().Size().X) / float32(usrc.Bounds().Size().X)
-		if sc > 1.2 {
-			fmt.Println("orig highres", sc)
-			rimg = uorig
+		if !reflectx.IsNil(reflect.ValueOf(uorig)) {
+			sc := float32(uorig.Bounds().Size().X) / float32(usrc.Bounds().Size().X)
+			if sc > 1.2 {
+				rimg = uorig
+			}
 		}
 	}
 

--- a/paint/renderers/svgrender/svgrender.go
+++ b/paint/renderers/svgrender/svgrender.go
@@ -6,6 +6,7 @@ package svgrender
 
 import (
 	"bytes"
+	"fmt"
 	"image"
 	"maps"
 
@@ -203,9 +204,19 @@ func (rs *Renderer) RenderImage(pr *pimage.Params) {
 	}
 
 	sz := pr.Rect.Size()
+	rimg := usrc
+	if pr.Original != nil {
+		uorig := imagex.Unwrap(pr.Original)
+		sc := float32(uorig.Bounds().Size().X) / float32(usrc.Bounds().Size().X)
+		if sc > 1.2 {
+			fmt.Println("orig highres", sc)
+			rimg = uorig
+		}
+	}
 
 	simg := svg.NewImage(cg)
-	simg.SetImage(usrc, float32(sz.X), float32(sz.Y))
+	simg.SetImage(rimg, 0, 0)
+	simg.Size.Set(float32(sz.X), float32(sz.Y))
 	simg.Pos = math32.FromPoint(pr.Rect.Min)
 	// todo: ViewBox?
 }

--- a/styles/units/gen.go
+++ b/styles/units/gen.go
@@ -67,6 +67,7 @@ func {{.Camel}}(value float32) Value {
 func (v *Value) {{.Camel}}(value float32) {
 	v.Value = value
 	v.Unit = Unit{{.Camel}}
+	v.Custom = nil
 }
 
 // {{.Camel}} converts the given {{.Lower}} value to dots.

--- a/styles/units/unitgen.go
+++ b/styles/units/unitgen.go
@@ -17,6 +17,7 @@ func Dp(value float32) Value {
 func (v *Value) Dp(value float32) {
 	v.Value = value
 	v.Unit = UnitDp
+	v.Custom = nil
 }
 
 // Dp converts the given dp value to dots.
@@ -36,6 +37,7 @@ func Px(value float32) Value {
 func (v *Value) Px(value float32) {
 	v.Value = value
 	v.Unit = UnitPx
+	v.Custom = nil
 }
 
 // Px converts the given px value to dots.
@@ -55,6 +57,7 @@ func Ew(value float32) Value {
 func (v *Value) Ew(value float32) {
 	v.Value = value
 	v.Unit = UnitEw
+	v.Custom = nil
 }
 
 // Ew converts the given ew value to dots.
@@ -74,6 +77,7 @@ func Eh(value float32) Value {
 func (v *Value) Eh(value float32) {
 	v.Value = value
 	v.Unit = UnitEh
+	v.Custom = nil
 }
 
 // Eh converts the given eh value to dots.
@@ -93,6 +97,7 @@ func Pw(value float32) Value {
 func (v *Value) Pw(value float32) {
 	v.Value = value
 	v.Unit = UnitPw
+	v.Custom = nil
 }
 
 // Pw converts the given pw value to dots.
@@ -112,6 +117,7 @@ func Ph(value float32) Value {
 func (v *Value) Ph(value float32) {
 	v.Value = value
 	v.Unit = UnitPh
+	v.Custom = nil
 }
 
 // Ph converts the given ph value to dots.
@@ -131,6 +137,7 @@ func Rem(value float32) Value {
 func (v *Value) Rem(value float32) {
 	v.Value = value
 	v.Unit = UnitRem
+	v.Custom = nil
 }
 
 // Rem converts the given rem value to dots.
@@ -150,6 +157,7 @@ func Em(value float32) Value {
 func (v *Value) Em(value float32) {
 	v.Value = value
 	v.Unit = UnitEm
+	v.Custom = nil
 }
 
 // Em converts the given em value to dots.
@@ -169,6 +177,7 @@ func Ex(value float32) Value {
 func (v *Value) Ex(value float32) {
 	v.Value = value
 	v.Unit = UnitEx
+	v.Custom = nil
 }
 
 // Ex converts the given ex value to dots.
@@ -188,6 +197,7 @@ func Ch(value float32) Value {
 func (v *Value) Ch(value float32) {
 	v.Value = value
 	v.Unit = UnitCh
+	v.Custom = nil
 }
 
 // Ch converts the given ch value to dots.
@@ -207,6 +217,7 @@ func Vw(value float32) Value {
 func (v *Value) Vw(value float32) {
 	v.Value = value
 	v.Unit = UnitVw
+	v.Custom = nil
 }
 
 // Vw converts the given vw value to dots.
@@ -226,6 +237,7 @@ func Vh(value float32) Value {
 func (v *Value) Vh(value float32) {
 	v.Value = value
 	v.Unit = UnitVh
+	v.Custom = nil
 }
 
 // Vh converts the given vh value to dots.
@@ -245,6 +257,7 @@ func Vmin(value float32) Value {
 func (v *Value) Vmin(value float32) {
 	v.Value = value
 	v.Unit = UnitVmin
+	v.Custom = nil
 }
 
 // Vmin converts the given vmin value to dots.
@@ -264,6 +277,7 @@ func Vmax(value float32) Value {
 func (v *Value) Vmax(value float32) {
 	v.Value = value
 	v.Unit = UnitVmax
+	v.Custom = nil
 }
 
 // Vmax converts the given vmax value to dots.
@@ -283,6 +297,7 @@ func Cm(value float32) Value {
 func (v *Value) Cm(value float32) {
 	v.Value = value
 	v.Unit = UnitCm
+	v.Custom = nil
 }
 
 // Cm converts the given cm value to dots.
@@ -302,6 +317,7 @@ func Mm(value float32) Value {
 func (v *Value) Mm(value float32) {
 	v.Value = value
 	v.Unit = UnitMm
+	v.Custom = nil
 }
 
 // Mm converts the given mm value to dots.
@@ -321,6 +337,7 @@ func Q(value float32) Value {
 func (v *Value) Q(value float32) {
 	v.Value = value
 	v.Unit = UnitQ
+	v.Custom = nil
 }
 
 // Q converts the given q value to dots.
@@ -340,6 +357,7 @@ func In(value float32) Value {
 func (v *Value) In(value float32) {
 	v.Value = value
 	v.Unit = UnitIn
+	v.Custom = nil
 }
 
 // In converts the given in value to dots.
@@ -359,6 +377,7 @@ func Pc(value float32) Value {
 func (v *Value) Pc(value float32) {
 	v.Value = value
 	v.Unit = UnitPc
+	v.Custom = nil
 }
 
 // Pc converts the given pc value to dots.
@@ -378,6 +397,7 @@ func Pt(value float32) Value {
 func (v *Value) Pt(value float32) {
 	v.Value = value
 	v.Unit = UnitPt
+	v.Custom = nil
 }
 
 // Pt converts the given pt value to dots.

--- a/svg/image.go
+++ b/svg/image.go
@@ -103,7 +103,7 @@ func (g *Image) DrawImage(sv *SVG) {
 		return
 	}
 	pc := g.Painter(sv)
-	pc.DrawImageScaled(g.Pixels.Image, g.Pos.X, g.Pos.Y, g.Size.X, g.Size.Y)
+	pc.DrawImageScaled(g.Pixels.Image, nil, g.Pos.X, g.Pos.Y, g.Size.X, g.Size.Y)
 }
 
 func (g *Image) LocalBBox(sv *SVG) math32.Box2 {


### PR DESCRIPTION
image rendering saves pointer to the original image, which can be used in PDF or SVG if it is significantly larger than rendered image.

also fix image sizing layout issue, where a Min style with only Y or X set will allow the other dim to expand to size of image.
