### PR TITLE
docs: align README minimum Go version with go.mod

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@
 
 Cogent Core is a free and open source framework for building powerful, fast, elegant 2D and 3D apps that run on macOS, Windows, Linux, iOS, Android, and web with a single Go codebase, allowing you to Code Once, Run Everywhere (Core). See the [website](https://cogentcore.org) for more information, including [extensive documentation](https://cogentcore.org/core) and interactive examples you can directly edit and run. The documentation itself is a Cogent Core app running on the web using wasm. You must complete the [install instructions](https://cogentcore.org/core/install) on the website before developing with Cogent Core on your system.
 
+Cogent Core requires Go 1.25.6 or later.
+
 ## Sponsors
 
 We thank our [sponsors](https://github.com/sponsors/cogentcore) for their support, which allows us to spend more time improving Cogent Core.


### PR DESCRIPTION
## Summary
- document the minimum supported Go version in README.md
- align the prerequisite with the `go 1.25.6` directive in go.mod

## Validation
- Verified the documented README version matches go.mod with a targeted Python check.
- Ran `git diff --check`.


<!-- repo-agent-case:0eeb3862-d27f-4ff3-a2bf-42a2c09a836b -->