### PR TITLE
indexmd: added support for custom index.html or index.md as a loading page

### DIFF
--- a/cmd/web/build.go
+++ b/cmd/web/build.go
@@ -137,7 +137,13 @@ func makeFiles(c *config.Config) error {
 	if c.About != "" {
 		prindex.Description = c.About
 	}
-	iht, err := makeIndexHTML(c, "", prindex)
+	// A custom index page replaces the pre-rendered preview of the root page
+	// only; the pre-rendered previews of any content pages are still used.
+	indexPage, err := readIndexPage()
+	if err != nil {
+		return err
+	}
+	iht, err := makeIndexHTML(c, "", prindex, indexPage)
 	if err != nil {
 		return err
 	}
@@ -157,7 +163,7 @@ func makeFiles(c *config.Config) error {
 			bpath404 = "http://localhost:8080/" // dev
 		}
 	}
-	notFound, err := makeIndexHTML(c, bpath404, prindex)
+	notFound, err := makeIndexHTML(c, bpath404, prindex, "")
 	if err != nil {
 		return err
 	}
@@ -208,7 +214,7 @@ func makePages(c *config.Config, prps []*bcontent.PreRenderPage) error {
 		if err != nil {
 			return err
 		}
-		b, err := makeIndexHTML(c, "../", prp)
+		b, err := makeIndexHTML(c, "../", prp, "")
 		if err != nil {
 			return err
 		}

--- a/cmd/web/embed/app.css
+++ b/cmd/web/embed/app.css
@@ -135,7 +135,10 @@ body > #app-crash-dialog {
   overflow: auto;
 }
 
-#app-wasm-loader * {
+/* This reset is for the loader chrome and the automatically pre-rendered
+   preview, which carries its own inline styles. A custom index page is
+   excluded, as it needs normal browser defaults. */
+#app-wasm-loader *:not(#app-index, #app-index *) {
   border: unset;
   margin-block: unset;
   font-family: unset;
@@ -144,4 +147,93 @@ body > #app-crash-dialog {
 #app-wasm-loader textarea {
   font-family: Roboto Mono, monospace;
   font-size: 16px;
+}
+
+/* Custom index page (index.html / index.md): */
+
+#app-index {
+  flex: 1;
+  min-height: 0; /* required, or a flex child will not shrink and will not scroll */
+  overflow: auto;
+  max-width: 55em;
+  margin-inline: auto;
+  line-height: 1.6;
+}
+
+/* These defaults are wrapped in :where() so that they contribute zero
+   specificity, which means that any styles in the custom index page itself
+   override them. */
+
+:where(#app-index) :where(h1, h2, h3, h4, h5, h6) {
+  line-height: 1.25;
+}
+
+:where(#app-index) :where(a) {
+  color: var(--primary-color);
+}
+
+:where(#app-index) :where(code, pre) {
+  font-family: Roboto Mono, monospace;
+  background-color: var(--surface-container-color);
+  border-radius: 4px;
+}
+
+:where(#app-index) :where(code) {
+  padding: 0.1em 0.3em;
+}
+
+:where(#app-index) :where(pre) {
+  padding: 0.75em;
+  overflow-x: auto;
+}
+
+:where(#app-index) :where(pre code) {
+  padding: 0;
+  background: none;
+}
+
+:where(#app-index) :where(blockquote) {
+  margin-inline: 0;
+  padding-inline-start: 1em;
+  border-inline-start: 4px solid var(--container-color);
+}
+
+:where(#app-index) :where(table) {
+  border-collapse: collapse;
+}
+
+:where(#app-index) :where(th, td) {
+  border: 1px solid var(--container-color);
+  padding: 0.4em 0.6em;
+}
+
+:where(#app-index) :where(img, svg, video) {
+  max-width: 100%;
+  height: auto;
+}
+
+:where(#app-index) :where(hr) {
+  border: none;
+  border-block-start: 1px solid var(--container-color);
+}
+
+/* The loader chrome becomes a compact strip when a custom index page is the
+   content, instead of a full loading screen. */
+
+#app-wasm-loader.has-index #app-wasm-loader-icon {
+  width: 2em;
+  height: 2em;
+}
+
+#app-wasm-loader.has-index #app-wasm-loader-title {
+  font-size: 16px;
+}
+
+#app-wasm-loader.has-index #app-wasm-loader-label {
+  font-size: 12px;
+  opacity: 0.7;
+}
+
+#app-wasm-loader.has-index #app-wasm-loader-progress {
+  height: 0.35em;
 }

--- a/cmd/web/embed/index.html
+++ b/cmd/web/embed/index.html
@@ -39,17 +39,21 @@
 
 <body role="application">
     <input id="app-text-field" type="text">
-    <div id="app-wasm-loader">
+    <div id="app-wasm-loader"{{if ne .IndexPage ""}} class="has-index"{{end}}>
         <header id="app-wasm-loader-header">
             <img id="app-wasm-loader-icon" src="{{.BasePath}}icons/svg.svg">
             <p id="app-wasm-loader-title">{{.SiteName}}</p>
             <p id="app-wasm-loader-label">0%</p>
             <progress id="app-wasm-loader-progress" value="0"></progress>
         </header>
+        {{- if ne .IndexPage ""}}
+        <div id="app-index">{{.IndexPage}}</div>
+        {{- else}}
         <h1>Loading...</h1>
         {{- if ne .PreRenderHTML ""}}
         <h3>Static preview:</h3>
         {{.PreRenderHTML}}
+        {{- end}}
         {{- end}}
     </div>
 </body>

--- a/cmd/web/index.go
+++ b/cmd/web/index.go
@@ -1,0 +1,57 @@
+// Copyright (c) 2026, Cogent Core. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package web
+
+import (
+	"errors"
+	"io/fs"
+	"os"
+
+	"cogentcore.org/core/content/bcontent"
+	"github.com/gomarkdown/markdown"
+	"github.com/gomarkdown/markdown/html"
+	"github.com/gomarkdown/markdown/parser"
+)
+
+// readIndexPage returns the HTML for the optional custom index page of the app,
+// which is an index.html file or an index.md file (converted from markdown) in
+// the app directory, with index.html taking precedence. It replaces the
+// automatically pre-rendered HTML preview of the root page in the generated
+// index.html file (see [makeIndexHTML]). The result is an HTML fragment that is
+// placed inside of the app loader element, not a complete HTML document, so that
+// the app keeps loading in the background while the user reads it. It returns ""
+// if the app does not have a custom index page.
+func readIndexPage() (string, error) {
+	b, err := os.ReadFile("index.html")
+	if err == nil {
+		return string(b), nil
+	}
+	if !errors.Is(err, fs.ErrNotExist) {
+		return "", err
+	}
+	// [bcontent.Page.ReadContent] removes any TOML front matter, which is
+	// ignored here but supported so that content pages can be used directly.
+	pg := &bcontent.Page{Source: os.DirFS("."), Filename: "index.md"}
+	b, err = pg.ReadContent(nil)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return "", nil
+		}
+		return "", err
+	}
+	return string(mdToHTML(b)), nil
+}
+
+// mdToHTML converts the given markdown to HTML for a custom index page (see
+// [readIndexPage]). Unlike [htmlcore.MDToHTML], this is a plain markdown
+// conversion without support for Cogent Core extensions such as wikilinks,
+// since those require the GUI packages, which the build tool can not import.
+func mdToHTML(md []byte) []byte {
+	extensions := parser.CommonExtensions | parser.AutoHeadingIDs | parser.NoEmptyLineBeforeBlock | parser.Attributes | parser.Mmark
+	p := parser.NewWithExtensions(extensions)
+	doc := p.Parse(md)
+	opts := html.RendererOptions{Flags: html.CommonFlags | html.HrefTargetBlank}
+	return markdown.Render(doc, html.NewRenderer(opts))
+}

--- a/cmd/web/tmpl.go
+++ b/cmd/web/tmpl.go
@@ -142,14 +142,16 @@ type indexHTMLData struct {
 	VanityURL              string
 	GithubVanityRepository string
 	PreRenderHTML          string
+	IndexPage              string
 }
 
 // makeIndexHTML exectues [indexHTMLTmpl] based on the given configuration information,
 // base path for app resources (used in [makePages]), optional title (used in [makePages],
 // defaults to [config.Config.Name] otherwise), optional page-specific description (used
 // in [makePages], defaults to [config.Config.About]), and pre-render HTML representation
-// of app content.
-func makeIndexHTML(c *config.Config, basePath string, prp *bcontent.PreRenderPage) ([]byte, error) {
+// of app content. If indexPage is non-empty, it is the HTML for the custom index page
+// of the app (see [readIndexPage]), which is used instead of the pre-render HTML.
+func makeIndexHTML(c *config.Config, basePath string, prp *bcontent.PreRenderPage, indexPage string) ([]byte, error) {
 	if prp.Description == "" {
 		prp.Description = c.About
 	} else {
@@ -169,6 +171,7 @@ func makeIndexHTML(c *config.Config, basePath string, prp *bcontent.PreRenderPag
 		VanityURL:              c.Web.VanityURL,
 		GithubVanityRepository: c.Web.GithubVanityRepository,
 		PreRenderHTML:          prp.HTML,
+		IndexPage:              indexPage,
 	}
 
 	b := &bytes.Buffer{}

--- a/docs/content/build.md
+++ b/docs/content/build.md
@@ -24,6 +24,14 @@ If there is an `icon.svg` file in the current directory, it will be used as the 
 
 For development on Android, you need to install [Android Studio](https://developer.android.com/studio), and for development on iOS, you need to install [XCode](https://apps.apple.com/us/app/xcode/id497799835?mt=12). For Android development, if you run into any errors with the Android NDK, you should ensure that it is [installed](https://developer.android.com/studio/projects/install-ndk#default-version). You may also need to add the Android tools [to your PATH](https://stackoverflow.com/a/29083170).
 
+## Web index page
+
+When building for web, the `core` tool generates an `index.html` file that loads the app. While the app is loading, it shows a preview of the app, which is automatically pre-rendered as HTML at build time. This preview is also what search engines and social media sites see.
+
+You can replace that automatic preview with your own content by making an `index.html` or `index.md` file (converted from markdown) in your app directory. If both exist, `index.html` is used. These files specify the body content, and are imported within a page that loads the app and sets default styles. Do not include `&lt;html&gt;`, `&lt;head&gt;`, or `&lt;body&gt;` elements.
+
+You can include a `&lt;script&gt;` element in your index page, and it will run, but note that the entire loader element is removed as soon as the app finishes its first render. Anything that the script registered, such as a timer or an event listener, keeps running after that, so it must clean up after itself.
+
 ## Details
 
 You can build for Android on all desktop platforms, and for iOS on macOS only. Cross-compiling between desktop platforms is planned but not yet supported.


### PR DESCRIPTION
for standalone apps, in situations where the generatehtml render is not useful. written by claude under guidance from kai.
